### PR TITLE
Support using with std-enabled serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ version = "0.5"
 features = ["serde"]
 
 [dependencies.serde]
-version = "1.0"
+version = "1.0.100"
 default-features = false
 features = ["derive"]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,3 +85,5 @@ impl serde::de::Error for Error {
         Error::SerdeDeCustom
     }
 }
+
+impl serde::ser::StdError for Error {}


### PR DESCRIPTION
Previously, using Postcard in a project that also uses std-enabled Serde did not work.

```toml
[dependencies]
serde = "1.0" # only works if we add default-features=false
postcard = "0.4"
```

```console
error[E0277]: the trait bound `error::Error: std::error::Error` is not satisfied
  --> postcard-0.4.0/src/error.rs:71:6
   |
71 | impl serde::ser::Error for Error {
   |      ^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `error::Error`
```

This PR makes Postcard compile whether or not Serde std is enabled.