### PR TITLE
Improvements to serialisation with `StdVec` for `use-std` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,11 @@ pub use de::deserializer::Deserializer;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
 pub use ser::{
-    flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs, to_stdvec,
-    to_stdvec_cobs, to_vec, to_vec_cobs,
+    flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs,
+    to_vec, to_vec_cobs,
+};
+
+#[cfg(feature = "use-std")]
+pub use ser::{
+    to_stdvec, to_stdvec_cobs
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@
 //! for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 //! dual licensed as above, without any additional terms or conditions.
 
-
 #![cfg_attr(not(any(test, feature = "use-std")), no_std)]
 #![warn(missing_docs)]
 
@@ -128,6 +127,6 @@ pub use de::deserializer::Deserializer;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
 pub use ser::{
-    flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs, to_vec,
-    to_vec_cobs,
+    flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs, to_stdvec,
+    to_stdvec_cobs, to_vec, to_vec_cobs,
 };

--- a/src/ser/flavors.rs
+++ b/src/ser/flavors.rs
@@ -226,7 +226,7 @@ impl<B: ArrayLength<u8>> Default for HVec<B> {
 ///
 /// This type is only available when the (non-default) `use-std` feature is active
 #[cfg(feature = "use-std")]
-pub struct StdVec(std::vec::Vec<u8>);
+pub struct StdVec(pub std::vec::Vec<u8>);
 
 #[cfg(feature = "use-std")]
 impl SerFlavor for StdVec {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -167,6 +167,7 @@ where
 /// let ser: Vec<u8> = to_stdvec("Hi!").unwrap();
 /// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
 /// ```
+#[cfg(feature = "use-std")]
 pub fn to_stdvec<T>(value: &T) -> Result<std::vec::Vec<u8>>
 where
     T: Serialize + ?Sized,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -185,10 +185,10 @@ where
 /// use postcard::to_stdvec_cobs;
 ///
 /// let ser: Vec<u8> = to_stdvec_cobs(&true).unwrap();
-/// assert_eq!(ser.as_slice(), &[0x01]);
+/// assert_eq!(ser.as_slice(), &[0x02, 0x01, 0x00]);
 ///
 /// let ser: Vec<u8> = to_stdvec_cobs("Hi!").unwrap();
-/// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
+/// assert_eq!(ser.as_slice(), &[0x05, 0x03, b'H', b'i', b'!', 0x00]);
 /// ```
 #[cfg(feature = "use-std")]
 pub fn to_stdvec_cobs<T>(value: &T) -> Result<std::vec::Vec<u8>>

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,6 +5,9 @@ use crate::error::{Error, Result};
 
 use crate::ser::flavors::{Cobs, HVec, SerFlavor, Slice};
 
+#[cfg(feature = "use-std")]
+use crate::ser::flavors::StdVec;
+
 use crate::ser::serializer::Serializer;
 
 pub mod flavors;
@@ -149,6 +152,52 @@ where
     B: ArrayLength<u8>,
 {
     serialize_with_flavor::<T, HVec<B>, Vec<u8, B>>(value, HVec::default())
+}
+
+/// Serialize a `T` to a `std::vec::Vec<u8>
+///
+/// ## Example
+///
+/// ```rust
+/// use postcard::to_stdvec;
+///
+/// let ser: Vec<u8> = to_stdvec(&true).unwrap();
+/// assert_eq!(ser.as_slice(), &[0x01]);
+///
+/// let ser: Vec<u8> = to_stdvec("Hi!").unwrap();
+/// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
+/// ```
+pub fn to_stdvec<T>(value: &T) -> Result<std::vec::Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    serialize_with_flavor::<T, StdVec, std::vec::Vec<u8>>(value, StdVec(std::vec::Vec::new()))
+}
+
+/// Serialize and COBS encode a `T` to a `std::vec::Vec<u8>`
+///
+/// The terminating sentinel `0x00` byte is included in the output.
+///
+/// ## Example
+///
+/// ```rust
+/// use postcard::to_stdvec_cobs;
+///
+/// let ser: Vec<u8> = to_stdvec_cobs(&true).unwrap();
+/// assert_eq!(ser.as_slice(), &[0x01]);
+///
+/// let ser: Vec<u8> = to_stdvec_cobs("Hi!").unwrap();
+/// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
+/// ```
+#[cfg(feature = "use-std")]
+pub fn to_stdvec_cobs<T>(value: &T) -> Result<std::vec::Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    serialize_with_flavor::<T, Cobs<StdVec>, std::vec::Vec<u8>>(
+        value,
+        Cobs::try_new(StdVec(std::vec::Vec::new()))?,
+    )
 }
 
 /// `serialize_with_flavor()` has three generic parameters, `T, F, O`.


### PR DESCRIPTION
This PR does two things:

1. Make the inner type of `StdVec` pub, so that it can be created
   manually outside of `postcard`.
2. Add `to_stdvec` and `to_stdvec_cobs` utility functions, to make it
   easier to directly serialise to these flavours

I also added doc tests, one of which fails which is a bit
strange. It's basically the same example as the `to_vec_cobs` doc
test. And I don't assume that the `std::vec::Vec<u8>` would handle
bytes drastically different from `heapless::Vec`...right? Anyway,
maybe you have some ideas there.