### PR TITLE
Add alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["James Munns <james.munns@ferrous-systems.com>"]
 edition = "2018"
 readme = "README.md"
@@ -26,6 +26,7 @@ all-features = true
 [dependencies.heapless]
 version = "0.5"
 features = ["serde"]
+optional = true
 
 [dependencies.serde]
 version = "1.0.100"
@@ -39,4 +40,5 @@ default-features = false
 
 [features]
 use-std = []
-defaults = []
+default = ["heapless"]
+alloc = ["serde/alloc"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ maximum value of `(1 << 32) - 1` as currently defined in Rust. Varints larger th
 ## Example - Serialization/Deserialization
 
 Postcard can serialize and deserialize messages similar to other `serde` formats.
+Using the default `heapless` feature to serialize to a `heapless::Vec<u8>`:
 
 ```rust
 use core::ops::Deref;
@@ -54,6 +55,41 @@ struct RefStruct<'a> {
 let message = "hElLo";
 let bytes = [0x01, 0x10, 0x02, 0x20];
 let output: Vec<u8, U11> = to_vec(&RefStruct {
+    bytes: &bytes,
+    str_s: message,
+}).unwrap();
+
+assert_eq!(
+    &[0x04, 0x01, 0x10, 0x02, 0x20, 0x05, b'h', b'E', b'l', b'L', b'o',],
+    output.deref()
+);
+
+let out: RefStruct = from_bytes(output.deref()).unwrap();
+assert_eq!(
+    out,
+    RefStruct {
+        bytes: &bytes,
+        str_s: message,
+    }
+);
+```
+
+Or the optional `alloc` feature to serialize to an `alloc::vec::Vec<u8>`:
+```rust
+use core::ops::Deref;
+use serde::{Serialize, Deserialize};
+use postcard::{from_bytes, to_allocvec};
+extern crate alloc;
+use alloc::vec::Vec;
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+struct RefStruct<'a> {
+    bytes: &'a [u8],
+    str_s: &'a str,
+}
+let message = "hElLo";
+let bytes = [0x01, 0x10, 0x02, 0x20];
+let output: Vec<u8> = to_allocvec(&RefStruct {
     bytes: &bytes,
     str_s: message,
 }).unwrap();

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -51,8 +51,9 @@ where
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#[cfg(feature = "heapless")]
 #[cfg(test)]
-mod test {
+mod test_heapless {
     use super::*;
     use crate::ser::to_vec;
     use core::fmt::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,10 @@
 //!
 //! Postcard can serialize and deserialize messages similar to other `serde` formats.
 //!
+//! Using the default `heapless` feature to serialize to a `heapless::Vec<u8>`:
+//!
 //! ```rust
+//! # #[cfg(feature = "heapless")] {
 //! use core::ops::Deref;
 //! use serde::{Serialize, Deserialize};
 //! use postcard::{from_bytes, to_vec};
@@ -68,6 +71,44 @@
 //!         str_s: message,
 //!     }
 //! );
+//! # }
+//! ```
+//!
+//! Or the optional `alloc` feature to serialize to an `alloc::vec::Vec<u8>`:
+//! ```rust
+//! # #[cfg(feature = "alloc")] {
+//! use core::ops::Deref;
+//! use serde::{Serialize, Deserialize};
+//! use postcard::{from_bytes, to_allocvec};
+//! extern crate alloc;
+//! use alloc::vec::Vec;
+//!
+//! #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+//! struct RefStruct<'a> {
+//!     bytes: &'a [u8],
+//!     str_s: &'a str,
+//! }
+//! let message = "hElLo";
+//! let bytes = [0x01, 0x10, 0x02, 0x20];
+//! let output: Vec<u8> = to_allocvec(&RefStruct {
+//!     bytes: &bytes,
+//!     str_s: message,
+//! }).unwrap();
+//!
+//! assert_eq!(
+//!     &[0x04, 0x01, 0x10, 0x02, 0x20, 0x05, b'h', b'E', b'l', b'L', b'o',],
+//!     output.deref()
+//! );
+//!
+//! let out: RefStruct = from_bytes(output.deref()).unwrap();
+//! assert_eq!(
+//!     out,
+//!     RefStruct {
+//!         bytes: &bytes,
+//!         str_s: message,
+//!     }
+//! );
+//! # }
 //! ```
 //!
 //! ## Example - Flavors
@@ -127,9 +168,14 @@ pub use de::deserializer::Deserializer;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
 pub use ser::{
-    flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs, to_vec,
-    to_vec_cobs,
+    flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs,
 };
+
+#[cfg(feature = "heapless")]
+pub use ser::{to_vec, to_vec_cobs};
 
 #[cfg(feature = "use-std")]
 pub use ser::{to_stdvec, to_stdvec_cobs};
+
+#[cfg(feature = "alloc")]
+pub use ser::{to_allocvec, to_allocvec_cobs};

--- a/tests/loopback.rs
+++ b/tests/loopback.rs
@@ -3,8 +3,14 @@
 use core::fmt::Debug;
 use core::fmt::Write;
 use core::ops::Deref;
+
+#[cfg(feature = "heapless")]
 use heapless::{consts::*, String, Vec};
-use postcard::{from_bytes, to_vec};
+
+#[cfg(feature = "heapless")]
+use postcard::to_vec;
+
+use postcard::from_bytes;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
@@ -52,6 +58,7 @@ struct RefStruct<'a> {
     str_s: &'a str,
 }
 
+#[cfg(feature = "heapless")]
 #[test]
 fn loopback() {
     // Basic types
@@ -163,6 +170,7 @@ fn loopback() {
     test_one(input, &[0x06, b'h', b'e', b'l', b'L', b'O', b'!']);
 }
 
+#[cfg(feature = "heapless")]
 fn test_one<'a, 'de, T>(data: T, ser_rep: &'a [u8])
 where
     T: Serialize + DeserializeOwned + Eq + PartialEq + Debug,


### PR DESCRIPTION
Closes #1 

Add support for alloc::vec::Vec behind the `alloc` feature.

After enabling alloc support, I realized that postcard users may wish to do away with the heapless flavor entirely, so I've put that behind a `heapless` feature, which is a default feature. It can be removed a la:
```
[dependencies.postcard]
version = "0.5.0"
default-features = false
features = ["alloc"]
```
Because the heapless flavor is now optional, it required some additional changes to tests and how `to_vec()` and `to_vec_cobs()` get included, but I've tried to keep those to a minimum where possible. If heapless is removed, it results in some significant savings in terms of additional dependencies, so I think having it behind a feature is worth it.