### PR TITLE
mark serializer/deserializer as not human readable

### DIFF
--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -84,6 +84,10 @@ impl<'a, 'b: 'a> serde::de::SeqAccess<'b> for SeqAccess<'a, 'b> {
 impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     type Error = Error;
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     // Postcard does not support structures not known at compile time
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
     where

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -41,6 +41,10 @@ where
     type SerializeStruct = Self;
     type SerializeStructVariant = Self;
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     fn serialize_bool(self, v: bool) -> Result<()> {
         self.serialize_u8(if v { 1 } else { 0 })
     }


### PR DESCRIPTION
This crate serializes the data in binary format, which is not human readable.

Ref: https://docs.serde.rs/serde/trait.Serializer.html#method.is_human_readable