### PR TITLE
Derive `Clone` for `Error`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 use core::fmt::{Display, Formatter};
 
 /// This is the error type used by Postcard
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// This is a feature that PostCard will never implement
     WontImplement,


### PR DESCRIPTION
We could easily derive `Copy` too, but I figured that it might be
desirable at some point to add non-Copy fields to a variant, which then
would be a breaking change.