### PR TITLE
Add missing size prefix for serialize_bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ version = "0.1.5-pre"
 default-features = false
 
 [features]
-use-std = []
+use-std = ["serde/std"]
 default = ["heapless"]
 alloc = ["serde/alloc"]

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -262,8 +262,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        // AJM - in serialize_bytes, we don't write the length first
-        // is this asymmetry intended?
         let sz = self.try_take_varint()?;
         let bytes: &'de [u8] = self.try_take_n(sz)?;
         visitor.visit_borrowed_bytes(bytes)

--- a/src/ser/flavors.rs
+++ b/src/ser/flavors.rs
@@ -72,6 +72,7 @@
 //! ```
 
 use crate::error::{Error, Result};
+use crate::varint::VarintUsize;
 use cobs::{EncoderState, PushResult};
 use core::ops::Index;
 use core::ops::IndexMut;
@@ -105,6 +106,15 @@ pub trait SerFlavor {
 
     /// The try_push() trait method can be used to push a single byte to be modified and/or stored
     fn try_push(&mut self, data: u8) -> core::result::Result<(), ()>;
+
+    /// The try_push_varint_usize() trait method can be used to push a `VarintUsize`. The default
+    /// implementation uses try_extend() to process the encoded `VarintUsize` bytes, which is likely
+    /// the desired behavior for most circumstances.
+    fn try_push_varint_usize(&mut self, data: &VarintUsize) -> core::result::Result<(), ()> {
+        let mut buf = VarintUsize::new_buf();
+        let used_buf = data.to_buf(&mut buf);
+        self.try_extend(used_buf)
+    }
 
     /// The release() trait method finalizes the modification or storage operation, and resolved into
     /// the type defined by `SerFlavor::Output` associated type.

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -493,6 +493,10 @@ mod test {
         let x: &[u8; 32] = &[0u8; 32];
         let output: Vec<u8, U128> = to_vec(x).unwrap();
         assert_eq!(output.len(), 32);
+
+        let x: &[u8] = &[0u8; 32];
+        let output: Vec<u8, U128> = to_vec(x).unwrap();
+        assert_eq!(output.len(), 33);
     }
 
     #[derive(Serialize)]
@@ -501,13 +505,6 @@ mod test {
     #[derive(Serialize)]
     pub struct TupleStruct((u8, u16));
 
-    #[derive(Serialize)]
-    struct ManyVarints {
-        a: VarintUsize,
-        b: VarintUsize,
-        c: VarintUsize,
-    }
-
     #[test]
     fn structs() {
         let output: Vec<u8, U4> = to_vec(&NewTypeStruct(5)).unwrap();
@@ -515,18 +512,6 @@ mod test {
 
         let output: Vec<u8, U3> = to_vec(&TupleStruct((0xA0, 0x1234))).unwrap();
         assert_eq!(&[0xA0, 0x34, 0x12], output.deref());
-
-        let output: Vec<u8, U128> = to_vec(&ManyVarints {
-            a: VarintUsize(0x01),
-            b: VarintUsize(0xFFFF_FFFF),
-            c: VarintUsize(0x07CD),
-        })
-        .unwrap();
-
-        assert_eq!(
-            &[0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0xCD, 0x0F,],
-            output.deref()
-        );
     }
 
     #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -116,7 +116,9 @@ where
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        VarintUsize(v.len()).serialize(&mut *self)?;
+        self.output
+            .try_push_varint_usize(&VarintUsize(v.len()))
+            .map_err(|_| Error::SerializeBufferFull)?;
         self.output
             .try_extend(v.as_bytes())
             .map_err(|_| Error::SerializeBufferFull)?;
@@ -124,6 +126,9 @@ where
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
+        self.output
+            .try_push_varint_usize(&VarintUsize(v.len()))
+            .map_err(|_| Error::SerializeBufferFull)?;
         self.output
             .try_extend(v)
             .map_err(|_| Error::SerializeBufferFull)
@@ -155,7 +160,9 @@ where
         variant_index: u32,
         _variant: &'static str,
     ) -> Result<()> {
-        VarintUsize(variant_index as usize).serialize(self)
+        self.output
+            .try_push_varint_usize(&VarintUsize(variant_index as usize))
+            .map_err(|_| Error::SerializeBufferFull)
     }
 
     fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
@@ -175,12 +182,16 @@ where
     where
         T: ?Sized + Serialize,
     {
-        VarintUsize(variant_index as usize).serialize(&mut *self)?;
+        self.output
+            .try_push_varint_usize(&VarintUsize(variant_index as usize))
+            .map_err(|_| Error::SerializeBufferFull)?;
         value.serialize(self)
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        VarintUsize(len.ok_or(Error::SerializeSeqLengthUnknown)?).serialize(&mut *self)?;
+        self.output
+            .try_push_varint_usize(&VarintUsize(len.ok_or(Error::SerializeSeqLengthUnknown)?))
+            .map_err(|_| Error::SerializeBufferFull)?;
         Ok(self)
     }
 
@@ -203,12 +214,16 @@ where
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        VarintUsize(variant_index as usize).serialize(&mut *self)?;
+        self.output
+            .try_push_varint_usize(&VarintUsize(variant_index as usize))
+            .map_err(|_| Error::SerializeBufferFull)?;
         Ok(self)
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
-        VarintUsize(len.ok_or(Error::SerializeSeqLengthUnknown)?).serialize(&mut *self)?;
+        self.output
+            .try_push_varint_usize(&VarintUsize(len.ok_or(Error::SerializeSeqLengthUnknown)?))
+            .map_err(|_| Error::SerializeBufferFull)?;
         Ok(self)
     }
 
@@ -223,7 +238,9 @@ where
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        VarintUsize(variant_index as usize).serialize(&mut *self)?;
+        self.output
+            .try_push_varint_usize(&VarintUsize(variant_index as usize))
+            .map_err(|_| Error::SerializeBufferFull)?;
         Ok(self)
     }
 

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -1,20 +1,7 @@
-use serde::{Serialize, Serializer};
-
 /// A wrapper type that exists as a `usize` at rest, but is serialized
 /// to or deserialized from a varint.
 #[derive(Debug)]
 pub struct VarintUsize(pub usize);
-
-impl Serialize for VarintUsize {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut buf = Self::new_buf();
-        let used_buf = self.to_buf(&mut buf);
-        serializer.serialize_bytes(used_buf)
-    }
-}
 
 /// Type alias for the largest buffer needed to store
 /// a `usize` varint as bytes

--- a/tests/loopback.rs
+++ b/tests/loopback.rs
@@ -175,6 +175,10 @@ fn loopback() {
     input.insert(0x03, 0x07).unwrap();
     input.insert(0x04, 0x08).unwrap();
     test_one(input, &[0x04, 0x01, 0x05, 0x02, 0x06, 0x03, 0x07, 0x04, 0x08]);
+
+    // `CString` (uses `serialize_bytes`/`deserialize_byte_buf`)
+    #[cfg(feature = "use-std")]
+    test_one(std::ffi::CString::new("heLlo").unwrap(), &[0x05, b'h', b'e', b'L', b'l', b'o']);
 }
 
 #[cfg(feature = "heapless")]


### PR DESCRIPTION
Serializer::serialize_bytes does not write the buffer size when
serializing, preventing deserialization from working properly when
serializing types that make use of this method (e.g. Bytes and BytesMut
from the bytes crate, CStr and CString from std::ffi). Simply adding the
missing size serialization breaks all size prefix serialization, as size
prefix serialization uses the existing Serializer::serialize_bytes
implementation to write the VarintUsize bytes to the output flavor.

This commit adds a try_push_varint_usize method to the SerFlavor trait
for writing out the encoded VarintUsize bytes, replacing all
VarintUsize::serialize calls with the SerFlavor method call, and adds
the same call to Serializer::serialize_bytes to ensure the size prefix
is now properly written. The VarintUsize::serialize implementation has
also been updated to serialize the encoded bytes as a tuple, mostly
retaining compatibility with the previous implementation while using
postcard's serializer, but potentially breaking compatibility with other
serializers. A deserialization test has also been added for
serialize_bytes output to mitigate possible regressions.

Fixes #21.