### PR TITLE
Add `heapless-cas` feature (enabled by default)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ all-features = true
 
 [dependencies.heapless]
 version = "0.5.4"
+default-features = false
 features = ["serde"]
 optional = true
 
@@ -40,5 +41,6 @@ default-features = false
 
 [features]
 use-std = ["serde/std"]
-default = ["heapless"]
+default = ["heapless-cas"]
+heapless-cas = ["heapless", "heapless/cas"]
 alloc = ["serde/alloc"]


### PR DESCRIPTION
I'm playing around with `postcard` on an custom target that doesn't support CAS. Luckily, `heapless` already includes a `cas` feature flag!


This PR adds a new enabled-by-default `heapless-cas` feature which corresponds to the `heapless/cas` feature.