### PR TITLE
Bump heapless, fixing unsoundness issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["James Munns <james.munns@ferrous-systems.com>"]
 edition = "2018"
 readme = "README.md"
@@ -24,7 +24,7 @@ all-features = true
 [dependencies]
 
 [dependencies.heapless]
-version = "0.5.4"
+version = "0.6.1"
 default-features = false
 features = ["serde"]
 optional = true


### PR DESCRIPTION
There was an unsoundness issue in heapless, making RustSec news: https://github.com/japaric/heapless/issues/181.
This is fixed in heapless 0.6.1.

The semver bump here is due to heapless 0.6 bumping generic-array to 0.14, which is useful in and of itself.

Think you can cut a release?