### PR TITLE
Add a `MaxSize` trait and derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,17 @@ default-features = false
 version = "0.3.0"
 optional = true
 
+[dependencies.postcard-derive]
+path = "postcard-derive"
+optional = true
+
 [features]
 use-std = ["serde/std"]
-default = ["heapless-cas"]
+default = ["heapless-cas", "derive"]
 heapless-cas = ["heapless", "heapless/cas"]
 alloc = ["serde/alloc"]
 use-defmt = ["defmt"]
+derive = ["postcard-derive"]
+
+[workspace]
+members = ["postcard-derive"]

--- a/postcard-derive/Cargo.toml
+++ b/postcard-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "postcard-derive"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/postcard-derive/src/lib.rs
+++ b/postcard-derive/src/lib.rs
@@ -1,0 +1,118 @@
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{parse_macro_input, parse_quote, DeriveInput, Generics, GenericParam, Data, spanned::Spanned, Fields};
+
+/// Derive the `postcard::MaxSize` trait for a struct or enum.
+#[proc_macro_derive(MaxSize)]
+pub fn derive_max_size(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+
+    let name = input.ident;
+
+    // Add a bound `T: MaxSize` to every type parameter T.
+    let generics = add_trait_bounds(input.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let sum = max_size_sum(&input.data);
+
+    let expanded = quote! {
+        impl #impl_generics ::postcard::MaxSize for #name #ty_generics #where_clause {
+            const POSTCARD_MAX_SIZE: usize = #sum;
+        }
+    };
+
+    expanded.into()
+}
+
+/// Add a bound `T: MaxSize` to every type parameter T.
+fn add_trait_bounds(mut generics: Generics) -> Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(parse_quote!(::postcard::MaxSize));
+        }
+    }
+    generics
+}
+
+/// Generate a constant expression that sums up the maximum size of the type.
+fn max_size_sum(data: &Data) -> TokenStream {
+    match data {
+        Data::Struct(data) => {
+            sum_fields(&data.fields)
+        }
+        Data::Enum(data) => {
+            let variant_count = data.variants.len();
+
+            let recurse = data.variants.iter().map(|v| {
+                sum_fields(&v.fields)
+            });
+
+            let discriminant_size = varint_size_discriminant(variant_count as u32) as usize;
+
+            // Generate a tree of max expressions.
+            let max = recurse.fold(quote!(0), |acc, x| {
+                quote! {
+                    {
+                        let lhs = #acc;
+                        let rhs = #x;
+                        if lhs > rhs {
+                            lhs
+                        } else {
+                            rhs
+                        }
+                    }
+                }
+            });
+
+            quote! {
+                #discriminant_size + #max
+            }
+        },
+        Data::Union(_) => unimplemented!(),
+    }
+}
+
+fn sum_fields(fields: &Fields) -> TokenStream {
+    match fields {
+        syn::Fields::Named(fields) => {
+            // Expands to an expression like
+            // 
+            //    0 + <Field1Type>::POSTCARD_MAX_SIZE + <Field2Type>::POSTCARD_MAX_SIZE + ...
+            // 
+            // but using fully qualified syntax.
+            
+            let recurse = fields.named.iter().map(|f| {
+                let ty = &f.ty;
+                quote_spanned! { f.span() => <#ty as ::postcard::MaxSize>::POSTCARD_MAX_SIZE }
+            });
+
+            quote! {
+                0 #(+ #recurse)*
+            }
+        },
+        syn::Fields::Unnamed(fields) => {
+            let recurse = fields.unnamed.iter().map(|f| {
+                let ty = &f.ty;
+                quote_spanned! { f.span() => <#ty as ::postcard::MaxSize>::POSTCARD_MAX_SIZE }
+            });
+
+            quote! {
+                0 #(+ #recurse)*
+            }
+        },
+        syn::Fields::Unit => quote!(0),
+    }
+}
+
+fn varint_size_discriminant(max_n: u32) -> u32 {
+    const BITS_PER_BYTE: u32 = 8;
+    const BITS_PER_VARINT_BYTE: u32 = 7;
+
+    // How many data bits do we need for `max_n`.
+    let bits = core::mem::size_of::<u32>() as u32 * BITS_PER_BYTE - max_n.leading_zeros();
+
+    let roundup_bits = bits + (BITS_PER_VARINT_BYTE - 1);
+
+    // Apply division, using normal "round down" integer division
+    roundup_bits / BITS_PER_VARINT_BYTE
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub use accumulator::{CobsAccumulator, FeedResult};
 pub use de::deserializer::Deserializer;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
-pub use ser::{flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs, max_size::SerializeMaxSize};
+pub use ser::{flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs, max_size::MaxSize};
 
 #[cfg(feature = "heapless")]
 pub use ser::{to_vec, to_vec_cobs};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,3 +194,6 @@ pub use ser::{to_stdvec, to_stdvec_cobs};
 
 #[cfg(feature = "alloc")]
 pub use ser::{to_allocvec, to_allocvec_cobs};
+
+#[cfg(feature = "derive")]
+pub use postcard_derive::MaxSize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub use accumulator::{CobsAccumulator, FeedResult};
 pub use de::deserializer::Deserializer;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
-pub use ser::{flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs};
+pub use ser::{flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs, max_size::SerializeMaxSize};
 
 #[cfg(feature = "heapless")]
 pub use ser::{to_vec, to_vec_cobs};

--- a/src/ser/max_size.rs
+++ b/src/ser/max_size.rs
@@ -5,184 +5,184 @@ use core::{
 
 /// This trait is used to enforce the maximum size required to
 /// store the serialization of a given type.
-pub trait SerializeMaxSize {
+pub trait MaxSize {
     /// The maximum possible size that the serialization of this
     /// type can have, in bytes.
-    const MAX_SIZE: usize;
+    const POSTCARD_MAX_SIZE: usize;
 }
 
-impl SerializeMaxSize for bool {
-    const MAX_SIZE: usize = 1;
+impl MaxSize for bool {
+    const POSTCARD_MAX_SIZE: usize = 1;
 }
 
-impl SerializeMaxSize for i8 {
-    const MAX_SIZE: usize = 1;
+impl MaxSize for i8 {
+    const POSTCARD_MAX_SIZE: usize = 1;
 }
 
-impl SerializeMaxSize for i16 {
-    const MAX_SIZE: usize = 2;
+impl MaxSize for i16 {
+    const POSTCARD_MAX_SIZE: usize = 2;
 }
 
-impl SerializeMaxSize for i32 {
-    const MAX_SIZE: usize = 4;
+impl MaxSize for i32 {
+    const POSTCARD_MAX_SIZE: usize = 4;
 }
 
-impl SerializeMaxSize for i64 {
-    const MAX_SIZE: usize = 8;
+impl MaxSize for i64 {
+    const POSTCARD_MAX_SIZE: usize = 8;
 }
 
-impl SerializeMaxSize for i128 {
-    const MAX_SIZE: usize = 8;
+impl MaxSize for i128 {
+    const POSTCARD_MAX_SIZE: usize = 8;
 }
 
-impl SerializeMaxSize for isize {
-    const MAX_SIZE: usize = i64::MAX_SIZE;
+impl MaxSize for isize {
+    const POSTCARD_MAX_SIZE: usize = i64::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for u8 {
-    const MAX_SIZE: usize = 1;
+impl MaxSize for u8 {
+    const POSTCARD_MAX_SIZE: usize = 1;
 }
 
-impl SerializeMaxSize for u16 {
-    const MAX_SIZE: usize = 2;
+impl MaxSize for u16 {
+    const POSTCARD_MAX_SIZE: usize = 2;
 }
 
-impl SerializeMaxSize for u32 {
-    const MAX_SIZE: usize = 4;
+impl MaxSize for u32 {
+    const POSTCARD_MAX_SIZE: usize = 4;
 }
 
-impl SerializeMaxSize for u64 {
-    const MAX_SIZE: usize = 8;
+impl MaxSize for u64 {
+    const POSTCARD_MAX_SIZE: usize = 8;
 }
 
-impl SerializeMaxSize for u128 {
-    const MAX_SIZE: usize = 8;
+impl MaxSize for u128 {
+    const POSTCARD_MAX_SIZE: usize = 8;
 }
 
-impl SerializeMaxSize for usize {
-    const MAX_SIZE: usize = u64::MAX_SIZE;
+impl MaxSize for usize {
+    const POSTCARD_MAX_SIZE: usize = u64::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for f32 {
-    const MAX_SIZE: usize = 4;
+impl MaxSize for f32 {
+    const POSTCARD_MAX_SIZE: usize = 4;
 }
 
-impl SerializeMaxSize for f64 {
-    const MAX_SIZE: usize = 8;
+impl MaxSize for f64 {
+    const POSTCARD_MAX_SIZE: usize = 8;
 }
 
-impl SerializeMaxSize for char {
-    const MAX_SIZE: usize = 5;
+impl MaxSize for char {
+    const POSTCARD_MAX_SIZE: usize = 5;
 }
 
-impl<T: SerializeMaxSize> SerializeMaxSize for Option<T> {
-    const MAX_SIZE: usize = T::MAX_SIZE + 1;
+impl<T: MaxSize> MaxSize for Option<T> {
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE + 1;
 }
 
-impl<T: SerializeMaxSize, E: SerializeMaxSize> SerializeMaxSize for Result<T, E> {
-    const MAX_SIZE: usize = max(T::MAX_SIZE, E::MAX_SIZE) + 1;
+impl<T: MaxSize, E: MaxSize> MaxSize for Result<T, E> {
+    const POSTCARD_MAX_SIZE: usize = max(T::POSTCARD_MAX_SIZE, E::POSTCARD_MAX_SIZE) + 1;
 }
 
-impl SerializeMaxSize for () {
-    const MAX_SIZE: usize = 0;
+impl MaxSize for () {
+    const POSTCARD_MAX_SIZE: usize = 0;
 }
 
-impl<T: SerializeMaxSize, const N: usize> SerializeMaxSize for [T; N] {
-    const MAX_SIZE: usize = T::MAX_SIZE * N;
+impl<T: MaxSize, const N: usize> MaxSize for [T; N] {
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE * N;
 }
 
-impl<T: SerializeMaxSize> SerializeMaxSize for &'_ T {
-    const MAX_SIZE: usize = T::MAX_SIZE;
+impl<T: MaxSize> MaxSize for &'_ T {
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
 }
 
-impl<T: SerializeMaxSize> SerializeMaxSize for &'_ mut T {
-    const MAX_SIZE: usize = T::MAX_SIZE;
+impl<T: MaxSize> MaxSize for &'_ mut T {
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroI8 {
-    const MAX_SIZE: usize = i8::MAX_SIZE;
+impl MaxSize for NonZeroI8 {
+    const POSTCARD_MAX_SIZE: usize = i8::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroI16 {
-    const MAX_SIZE: usize = i16::MAX_SIZE;
+impl MaxSize for NonZeroI16 {
+    const POSTCARD_MAX_SIZE: usize = i16::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroI32 {
-    const MAX_SIZE: usize = i32::MAX_SIZE;
+impl MaxSize for NonZeroI32 {
+    const POSTCARD_MAX_SIZE: usize = i32::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroI64 {
-    const MAX_SIZE: usize = i64::MAX_SIZE;
+impl MaxSize for NonZeroI64 {
+    const POSTCARD_MAX_SIZE: usize = i64::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroI128 {
-    const MAX_SIZE: usize = i128::MAX_SIZE;
+impl MaxSize for NonZeroI128 {
+    const POSTCARD_MAX_SIZE: usize = i128::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroIsize {
-    const MAX_SIZE: usize = isize::MAX_SIZE;
+impl MaxSize for NonZeroIsize {
+    const POSTCARD_MAX_SIZE: usize = isize::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroU8 {
-    const MAX_SIZE: usize = u8::MAX_SIZE;
+impl MaxSize for NonZeroU8 {
+    const POSTCARD_MAX_SIZE: usize = u8::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroU16 {
-    const MAX_SIZE: usize = u16::MAX_SIZE;
+impl MaxSize for NonZeroU16 {
+    const POSTCARD_MAX_SIZE: usize = u16::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroU32 {
-    const MAX_SIZE: usize = u32::MAX_SIZE;
+impl MaxSize for NonZeroU32 {
+    const POSTCARD_MAX_SIZE: usize = u32::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroU64 {
-    const MAX_SIZE: usize = u64::MAX_SIZE;
+impl MaxSize for NonZeroU64 {
+    const POSTCARD_MAX_SIZE: usize = u64::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroU128 {
-    const MAX_SIZE: usize = u128::MAX_SIZE;
+impl MaxSize for NonZeroU128 {
+    const POSTCARD_MAX_SIZE: usize = u128::POSTCARD_MAX_SIZE;
 }
 
-impl SerializeMaxSize for NonZeroUsize {
-    const MAX_SIZE: usize = usize::MAX_SIZE;
+impl MaxSize for NonZeroUsize {
+    const POSTCARD_MAX_SIZE: usize = usize::POSTCARD_MAX_SIZE;
 }
 
-impl<T: SerializeMaxSize> SerializeMaxSize for PhantomData<T> {
-    const MAX_SIZE: usize = 0;
+impl<T: MaxSize> MaxSize for PhantomData<T> {
+    const POSTCARD_MAX_SIZE: usize = 0;
 }
 
-impl<A: SerializeMaxSize> SerializeMaxSize for (A,) {
-    const MAX_SIZE: usize = A::MAX_SIZE;
+impl<A: MaxSize> MaxSize for (A,) {
+    const POSTCARD_MAX_SIZE: usize = A::POSTCARD_MAX_SIZE;
 }
 
-impl<A: SerializeMaxSize, B: SerializeMaxSize> SerializeMaxSize for (A, B) {
-    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE;
+impl<A: MaxSize, B: MaxSize> MaxSize for (A, B) {
+    const POSTCARD_MAX_SIZE: usize = A::POSTCARD_MAX_SIZE + B::POSTCARD_MAX_SIZE;
 }
 
-impl<A: SerializeMaxSize, B: SerializeMaxSize, C: SerializeMaxSize> SerializeMaxSize for (A, B, C) {
-    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE + C::MAX_SIZE;
+impl<A: MaxSize, B: MaxSize, C: MaxSize> MaxSize for (A, B, C) {
+    const POSTCARD_MAX_SIZE: usize = A::POSTCARD_MAX_SIZE + B::POSTCARD_MAX_SIZE + C::POSTCARD_MAX_SIZE;
 }
 
-impl<A: SerializeMaxSize, B: SerializeMaxSize, C: SerializeMaxSize, D: SerializeMaxSize> SerializeMaxSize for (A, B, C, D) {
-    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE + C::MAX_SIZE + D::MAX_SIZE;
+impl<A: MaxSize, B: MaxSize, C: MaxSize, D: MaxSize> MaxSize for (A, B, C, D) {
+    const POSTCARD_MAX_SIZE: usize = A::POSTCARD_MAX_SIZE + B::POSTCARD_MAX_SIZE + C::POSTCARD_MAX_SIZE + D::POSTCARD_MAX_SIZE;
 }
 
-impl<A: SerializeMaxSize, B: SerializeMaxSize, C: SerializeMaxSize, D: SerializeMaxSize, E: SerializeMaxSize> SerializeMaxSize for (A, B, C, D, E) {
-    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE + C::MAX_SIZE + D::MAX_SIZE + E::MAX_SIZE;
+impl<A: MaxSize, B: MaxSize, C: MaxSize, D: MaxSize, E: MaxSize> MaxSize for (A, B, C, D, E) {
+    const POSTCARD_MAX_SIZE: usize = A::POSTCARD_MAX_SIZE + B::POSTCARD_MAX_SIZE + C::POSTCARD_MAX_SIZE + D::POSTCARD_MAX_SIZE + E::POSTCARD_MAX_SIZE;
 }
 
-impl<A: SerializeMaxSize, B: SerializeMaxSize, C: SerializeMaxSize, D: SerializeMaxSize, E: SerializeMaxSize, F: SerializeMaxSize> SerializeMaxSize for (A, B, C, D, E, F) {
-    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE + C::MAX_SIZE + D::MAX_SIZE + E::MAX_SIZE + F::MAX_SIZE;
-}
-
-#[cfg(feature = "heapless")]
-impl<T: SerializeMaxSize, const N: usize> SerializeMaxSize for heapless::Vec<T, N> {
-    const MAX_SIZE: usize = <[T; N]>::MAX_SIZE + varint_size(N);
+impl<A: MaxSize, B: MaxSize, C: MaxSize, D: MaxSize, E: MaxSize, F: MaxSize> MaxSize for (A, B, C, D, E, F) {
+    const POSTCARD_MAX_SIZE: usize = A::POSTCARD_MAX_SIZE + B::POSTCARD_MAX_SIZE + C::POSTCARD_MAX_SIZE + D::POSTCARD_MAX_SIZE + E::POSTCARD_MAX_SIZE + F::POSTCARD_MAX_SIZE;
 }
 
 #[cfg(feature = "heapless")]
-impl<const N: usize> SerializeMaxSize for heapless::String<N> {
-    const MAX_SIZE: usize = <[u8; N]>::MAX_SIZE + varint_size(N);
+impl<T: MaxSize, const N: usize> MaxSize for heapless::Vec<T, N> {
+    const POSTCARD_MAX_SIZE: usize = <[T; N]>::POSTCARD_MAX_SIZE + varint_size(N);
+}
+
+#[cfg(feature = "heapless")]
+impl<const N: usize> MaxSize for heapless::String<N> {
+    const POSTCARD_MAX_SIZE: usize = <[u8; N]>::POSTCARD_MAX_SIZE + varint_size(N);
 }
 
 const fn varint_size(max_n: usize) -> usize {

--- a/src/ser/max_size.rs
+++ b/src/ser/max_size.rs
@@ -189,6 +189,10 @@ const fn varint_size(max_n: usize) -> usize {
     const BITS_PER_BYTE: usize = 8;
     const BITS_PER_VARINT_BYTE: usize = 7;
 
+    if max_n == 0 {
+        return 1;
+    }
+
     // How many data bits do we need for `max_n`.
     let bits = core::mem::size_of::<usize>() * BITS_PER_BYTE - max_n.leading_zeros() as usize;
 

--- a/src/ser/max_size.rs
+++ b/src/ser/max_size.rs
@@ -1,0 +1,210 @@
+use core::{
+    num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize},
+    marker::PhantomData,
+};
+
+/// This trait is used to enforce the maximum size required to
+/// store the serialization of a given type.
+pub trait SerializeMaxSize {
+    /// The maximum possible size that the serialization of this
+    /// type can have, in bytes.
+    const MAX_SIZE: usize;
+}
+
+impl SerializeMaxSize for bool {
+    const MAX_SIZE: usize = 1;
+}
+
+impl SerializeMaxSize for i8 {
+    const MAX_SIZE: usize = 1;
+}
+
+impl SerializeMaxSize for i16 {
+    const MAX_SIZE: usize = 2;
+}
+
+impl SerializeMaxSize for i32 {
+    const MAX_SIZE: usize = 4;
+}
+
+impl SerializeMaxSize for i64 {
+    const MAX_SIZE: usize = 8;
+}
+
+impl SerializeMaxSize for i128 {
+    const MAX_SIZE: usize = 8;
+}
+
+impl SerializeMaxSize for isize {
+    const MAX_SIZE: usize = i64::MAX_SIZE;
+}
+
+impl SerializeMaxSize for u8 {
+    const MAX_SIZE: usize = 1;
+}
+
+impl SerializeMaxSize for u16 {
+    const MAX_SIZE: usize = 2;
+}
+
+impl SerializeMaxSize for u32 {
+    const MAX_SIZE: usize = 4;
+}
+
+impl SerializeMaxSize for u64 {
+    const MAX_SIZE: usize = 8;
+}
+
+impl SerializeMaxSize for u128 {
+    const MAX_SIZE: usize = 8;
+}
+
+impl SerializeMaxSize for usize {
+    const MAX_SIZE: usize = u64::MAX_SIZE;
+}
+
+impl SerializeMaxSize for f32 {
+    const MAX_SIZE: usize = 4;
+}
+
+impl SerializeMaxSize for f64 {
+    const MAX_SIZE: usize = 8;
+}
+
+impl SerializeMaxSize for char {
+    const MAX_SIZE: usize = 5;
+}
+
+impl<T: SerializeMaxSize> SerializeMaxSize for Option<T> {
+    const MAX_SIZE: usize = T::MAX_SIZE + 1;
+}
+
+impl<T: SerializeMaxSize, E: SerializeMaxSize> SerializeMaxSize for Result<T, E> {
+    const MAX_SIZE: usize = max(T::MAX_SIZE, E::MAX_SIZE) + 1;
+}
+
+impl SerializeMaxSize for () {
+    const MAX_SIZE: usize = 0;
+}
+
+impl<T: SerializeMaxSize, const N: usize> SerializeMaxSize for [T; N] {
+    const MAX_SIZE: usize = T::MAX_SIZE * N;
+}
+
+impl<T: SerializeMaxSize> SerializeMaxSize for &'_ T {
+    const MAX_SIZE: usize = T::MAX_SIZE;
+}
+
+impl<T: SerializeMaxSize> SerializeMaxSize for &'_ mut T {
+    const MAX_SIZE: usize = T::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroI8 {
+    const MAX_SIZE: usize = i8::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroI16 {
+    const MAX_SIZE: usize = i16::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroI32 {
+    const MAX_SIZE: usize = i32::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroI64 {
+    const MAX_SIZE: usize = i64::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroI128 {
+    const MAX_SIZE: usize = i128::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroIsize {
+    const MAX_SIZE: usize = isize::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroU8 {
+    const MAX_SIZE: usize = u8::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroU16 {
+    const MAX_SIZE: usize = u16::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroU32 {
+    const MAX_SIZE: usize = u32::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroU64 {
+    const MAX_SIZE: usize = u64::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroU128 {
+    const MAX_SIZE: usize = u128::MAX_SIZE;
+}
+
+impl SerializeMaxSize for NonZeroUsize {
+    const MAX_SIZE: usize = usize::MAX_SIZE;
+}
+
+impl<T: SerializeMaxSize> SerializeMaxSize for PhantomData<T> {
+    const MAX_SIZE: usize = 0;
+}
+
+impl<A: SerializeMaxSize> SerializeMaxSize for (A,) {
+    const MAX_SIZE: usize = A::MAX_SIZE;
+}
+
+impl<A: SerializeMaxSize, B: SerializeMaxSize> SerializeMaxSize for (A, B) {
+    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE;
+}
+
+impl<A: SerializeMaxSize, B: SerializeMaxSize, C: SerializeMaxSize> SerializeMaxSize for (A, B, C) {
+    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE + C::MAX_SIZE;
+}
+
+impl<A: SerializeMaxSize, B: SerializeMaxSize, C: SerializeMaxSize, D: SerializeMaxSize> SerializeMaxSize for (A, B, C, D) {
+    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE + C::MAX_SIZE + D::MAX_SIZE;
+}
+
+impl<A: SerializeMaxSize, B: SerializeMaxSize, C: SerializeMaxSize, D: SerializeMaxSize, E: SerializeMaxSize> SerializeMaxSize for (A, B, C, D, E) {
+    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE + C::MAX_SIZE + D::MAX_SIZE + E::MAX_SIZE;
+}
+
+impl<A: SerializeMaxSize, B: SerializeMaxSize, C: SerializeMaxSize, D: SerializeMaxSize, E: SerializeMaxSize, F: SerializeMaxSize> SerializeMaxSize for (A, B, C, D, E, F) {
+    const MAX_SIZE: usize = A::MAX_SIZE + B::MAX_SIZE + C::MAX_SIZE + D::MAX_SIZE + E::MAX_SIZE + F::MAX_SIZE;
+}
+
+#[cfg(feature = "heapless")]
+impl<T: SerializeMaxSize, const N: usize> SerializeMaxSize for heapless::Vec<T, N> {
+    const MAX_SIZE: usize = <[T; N]>::MAX_SIZE + varint_size(N);
+}
+
+#[cfg(feature = "heapless")]
+impl<const N: usize> SerializeMaxSize for heapless::String<N> {
+    const MAX_SIZE: usize = <[u8; N]>::MAX_SIZE + varint_size(N);
+}
+
+const fn varint_size(max_n: usize) -> usize {
+    const BITS_PER_BYTE: usize = 8;
+    const BITS_PER_VARINT_BYTE: usize = 7;
+
+    // How many data bits do we need for `max_n`.
+    let bits = core::mem::size_of::<usize>() * BITS_PER_BYTE - max_n.leading_zeros() as usize;
+
+    // We add (BITS_PER_BYTE - 1), to ensure any integer divisions
+    // with a remainder will always add exactly one full byte, but
+    // an evenly divided number of bits will be the same
+    let roundup_bits = bits + (BITS_PER_BYTE - 1);
+
+    // Apply division, using normal "round down" integer division
+    roundup_bits / BITS_PER_VARINT_BYTE
+}
+
+const fn max(lhs: usize, rhs: usize) -> usize {
+    if lhs > rhs {
+        lhs
+    } else {
+        rhs
+    }
+}

--- a/src/ser/max_size.rs
+++ b/src/ser/max_size.rs
@@ -195,7 +195,7 @@ const fn varint_size(max_n: usize) -> usize {
     // We add (BITS_PER_BYTE - 1), to ensure any integer divisions
     // with a remainder will always add exactly one full byte, but
     // an evenly divided number of bits will be the same
-    let roundup_bits = bits + (BITS_PER_BYTE - 1);
+    let roundup_bits = bits + (BITS_PER_VARINT_BYTE - 1);
 
     // Apply division, using normal "round down" integer division
     roundup_bits / BITS_PER_VARINT_BYTE

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -21,6 +21,7 @@ use crate::ser::serializer::Serializer;
 
 pub mod flavors;
 pub(crate) mod serializer;
+pub(crate) mod max_size;
 
 /// Serialize a `T` to the given slice, with the resulting slice containing
 /// data in a serialized then COBS encoded format. The terminating sentinel `0x00` byte is included

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -33,3 +33,13 @@ fn test_enum_max_size() {
 
     assert_eq!(Baz::POSTCARD_MAX_SIZE, 0);
 }
+
+// #[cfg(feature = "derive")]
+// #[test]
+// fn test_union_max_size() {
+//     #[derive(postcard::MaxSize)]
+//     union Foo {
+//         a: u16,
+//         b: Option<u8>,
+//     }
+// }

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -58,6 +58,10 @@ fn test_vec_edge_cases() {
 
     let mut buf = [0; 16400];
 
+    test_equals::<0>(&mut buf);
+    test_equals::<1>(&mut buf);
+    test_equals::<2>(&mut buf);
+
     test_equals::<127>(&mut buf);
     test_equals::<128>(&mut buf);
     test_equals::<129>(&mut buf);

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -1,0 +1,35 @@
+#![allow(unused_imports)]
+
+#[cfg(feature = "derive")]
+#[test]
+fn test_struct_max_size() {
+    use postcard::MaxSize;
+
+    #[derive(MaxSize)]
+    struct Foo {
+        _a: u16,
+        _b: Option<u8>,
+    }
+
+    assert_eq!(Foo::POSTCARD_MAX_SIZE, 4);
+}
+
+#[cfg(feature = "derive")]
+#[test]
+fn test_enum_max_size() {
+    use postcard::MaxSize;
+
+    #[allow(dead_code)]
+    #[derive(MaxSize)]
+    enum Bar {
+        A(u16),
+        B(u8),
+    }
+
+    assert_eq!(Bar::POSTCARD_MAX_SIZE, 3);
+
+    #[derive(MaxSize)]
+    enum Baz {}
+
+    assert_eq!(Baz::POSTCARD_MAX_SIZE, 0);
+}


### PR DESCRIPTION
This adds a trait `MaxSize`:

```rust
pub trait MaxSize {
    /// The maximum possible size that the serialization of this
    /// type can have, in bytes.
    const POSTCARD_MAX_SIZE: usize;
}
```

and a derive macro that implements it for structs and enums.

I think this just needs a little more documentation and then it'll be ready to merge. I would like someone else to double check my logic for computing the varint size though.

The naming needs a little more work too. I'm not super happy with the trait and constant name.