### PR TITLE
Fixint wrapper type.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub use de::deserializer::Deserializer;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
 pub use ser::{flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs};
+pub use varint::Fixint;
 
 #[cfg(feature = "heapless")]
 pub use ser::{to_vec, to_vec_cobs};

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize, Serializer};
+
 /// A wrapper type that exists as a `usize` at rest, but is serialized
 /// to or deserialized from a varint.
 #[derive(Debug)]
@@ -48,3 +50,51 @@ impl VarintUsize {
         roundup_bits / BITS_PER_VARINT_BYTE
     }
 }
+
+/// Type wrapper that disables varint serialization/deserialization
+/// for the wrapped integer. The contained integer will always be serialized
+/// in the same way as a fixed size array.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "use-defmt", derive(defmt::Format))]
+#[repr(transparent)]
+pub struct Fixint<T>(pub T);
+
+macro_rules! impl_fixint {
+    ($( $int:ty ),*) => {
+        $(
+            impl From<$int> for Fixint<$int> {
+                fn from(x: $int) -> Self {
+                    Self(x)
+                }
+            }
+
+            impl From<Fixint<$int>> for $int {
+                fn from(x: Fixint<$int>) -> $int {
+                    x.0
+                }
+            }
+
+            impl Serialize for Fixint<$int> {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    self.0.to_le_bytes().serialize(serializer)
+                }
+            }
+
+            impl<'de> Deserialize<'de> for Fixint<$int> {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    <_ as Deserialize>::deserialize(deserializer)
+                        .map(<$int>::from_le_bytes)
+                        .map(Self)
+                }
+            }
+        )*
+    };
+}
+
+impl_fixint![i16, i32, i64, i128, u16, u32, u64, u128];


### PR DESCRIPTION
This PR adds a `Fixint<T>` that forces integers to be serialized as a fixed-size array.