### PR TITLE
Optimize varint decode

### DIFF
--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -2,7 +2,7 @@ use serde::de::{self, DeserializeSeed, IntoDeserializer, Visitor};
 
 use crate::de::flavors::{Flavor, Slice};
 use crate::error::{Error, Result};
-use crate::varint::varint_max;
+use crate::varint::{max_of_last_byte, varint_max};
 use core::marker::PhantomData;
 
 /// A `serde` compatible deserializer, generic over “Flavors” of deserializing plugins.
@@ -59,20 +59,18 @@ impl<'de, F: Flavor<'de>> Deserializer<'de, F> {
     #[inline]
     fn try_take_varint_u16(&mut self) -> Result<u16> {
         let mut out = 0;
-        let mut check = u16::MAX;
         for i in 0..varint_max::<u16>() {
             let val = self.flavor.pop()?;
             let carry = (val & 0x7F) as u16;
             out |= carry << (7 * i);
 
             if (val & 0x80) == 0 {
-                if carry > check {
+                if i == varint_max::<u16>() - 1 && val > max_of_last_byte::<u16>() {
                     return Err(Error::DeserializeBadVarint);
                 } else {
                     return Ok(out);
                 }
             }
-            check >>= 7;
         }
         Err(Error::DeserializeBadVarint)
     }
@@ -80,20 +78,18 @@ impl<'de, F: Flavor<'de>> Deserializer<'de, F> {
     #[inline]
     fn try_take_varint_u32(&mut self) -> Result<u32> {
         let mut out = 0;
-        let mut check = u32::MAX;
         for i in 0..varint_max::<u32>() {
             let val = self.flavor.pop()?;
             let carry = (val & 0x7F) as u32;
             out |= carry << (7 * i);
 
             if (val & 0x80) == 0 {
-                if carry > check {
+                if i == varint_max::<u32>() - 1 && val > max_of_last_byte::<u32>() {
                     return Err(Error::DeserializeBadVarint);
                 } else {
                     return Ok(out);
                 }
             }
-            check >>= 7;
         }
         Err(Error::DeserializeBadVarint)
     }
@@ -101,20 +97,18 @@ impl<'de, F: Flavor<'de>> Deserializer<'de, F> {
     #[inline]
     fn try_take_varint_u64(&mut self) -> Result<u64> {
         let mut out = 0;
-        let mut check = u64::MAX;
         for i in 0..varint_max::<u64>() {
             let val = self.flavor.pop()?;
             let carry = (val & 0x7F) as u64;
             out |= carry << (7 * i);
 
             if (val & 0x80) == 0 {
-                if carry > check {
+                if i == varint_max::<u64>() - 1 && val > max_of_last_byte::<u64>() {
                     return Err(Error::DeserializeBadVarint);
                 } else {
                     return Ok(out);
                 }
             }
-            check >>= 7;
         }
         Err(Error::DeserializeBadVarint)
     }
@@ -122,20 +116,18 @@ impl<'de, F: Flavor<'de>> Deserializer<'de, F> {
     #[inline]
     fn try_take_varint_u128(&mut self) -> Result<u128> {
         let mut out = 0;
-        let mut check = u128::MAX;
         for i in 0..varint_max::<u128>() {
             let val = self.flavor.pop()?;
             let carry = (val & 0x7F) as u128;
             out |= carry << (7 * i);
 
             if (val & 0x80) == 0 {
-                if carry > check {
+                if i == varint_max::<u128>() - 1 && val > max_of_last_byte::<u128>() {
                     return Err(Error::DeserializeBadVarint);
                 } else {
                     return Ok(out);
                 }
             }
-            check >>= 7;
         }
         Err(Error::DeserializeBadVarint)
     }

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -1,3 +1,4 @@
+/// Returns the maximum number of bytes required to encode T.
 pub const fn varint_max<T: Sized>() -> usize {
     const BITS_PER_BYTE: usize = 8;
     const BITS_PER_VARINT_BYTE: usize = 7;
@@ -12,6 +13,13 @@ pub const fn varint_max<T: Sized>() -> usize {
 
     // Apply division, using normal "round down" integer division
     roundup_bits / BITS_PER_VARINT_BYTE
+}
+
+/// Returns the maximum value stored in the last encoded byte.
+pub const fn max_of_last_byte<T: Sized>() -> u8 {
+    let max_bits = core::mem::size_of::<T>() * 8;
+    let extra_bits = max_bits % 7;
+    (1 << extra_bits) - 1
 }
 
 #[inline]


### PR DESCRIPTION
It's not necessary to update a check value in every cycle - it's only relevant while processing the last encoded byte.

Obligatory godbolt link, this time with x86 asm because I was lazy: https://rust.godbolt.org/z/hMh3qW67h