### PR TITLE
Add support for 16-bit and 8-bit architectures

### DIFF
--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -44,6 +44,18 @@ impl<'de> Deserializer<'de, Slice<'de>> {
 }
 
 impl<'de, F: Flavor<'de>> Deserializer<'de, F> {
+    #[cfg(target_pointer_width = "8")]
+    #[inline(always)]
+    fn try_take_varint_usize(&mut self) -> Result<usize> {
+        self.try_take_varint_u8().map(|u| u as usize)
+    }
+
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn try_take_varint_usize(&mut self) -> Result<usize> {
+        self.try_take_varint_u16().map(|u| u as usize)
+    }
+
     #[cfg(target_pointer_width = "32")]
     #[inline(always)]
     fn try_take_varint_usize(&mut self) -> Result<usize> {


### PR DESCRIPTION
For example, the ATmega328P I'm using right now has an 8-bit architecture. It seems this change is all that's needed to make postcard work on that MC, but I'll add a comment once I actually tried it out.