### PR TITLE
Make fixints usable through serde field attributes instead of wrappers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod accumulator;
 mod de;
 mod error;
+pub mod fixint;
 mod ser;
 mod varint;
 
@@ -61,8 +62,6 @@ pub mod experimental {
         // NOTE: ...and this is the derive macro
         pub use postcard_derive::MaxSize;
     }
-
-    #[cfg(feature = "experimental-derive")]
 
     /// Compile time Schema generation
     #[cfg(feature = "experimental-derive")]


### PR DESCRIPTION
This changes the (thankfully not public, by shear accident), `fixint` module to be usable through the `#[serde(with = ...)]` field attribute instead of wrappers. 

For example:
```rust
#[derive(Serialize, Deserialize)]
pub struct DefinitelyBE {
    #[serde(with = "crate::fixint::be")]
    x: u16,
}
```