### PR TITLE
Bump postcard-derive version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ optional = true
 
 [dependencies.postcard-derive]
 path = "./postcard-derive"
-version = "0.1"
+version = "0.1.1"
 optional = true
 
 [features]

--- a/postcard-derive/Cargo.toml
+++ b/postcard-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard-derive"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Lachlan Sneff <lachlan.sneff@gmail.com>",
     "James Munns <james@onevariable.com>",


### PR DESCRIPTION
I forgot to bump the derive crate version :(

Issue #73 isn't fixed for crates.io downloads without this.