### PR TITLE
Add a Schema impl for `std::string::String` with the `use-std` feature and for `alloc::string::String` with `alloc`

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -250,6 +250,14 @@ impl<T: Schema> Schema for std::vec::Vec<T> {
     };
 }
 
+#[cfg(feature = "use-std")]
+impl Schema for std::string::String {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "String",
+        ty: &SdmTy::String,
+    };
+}
+
 #[cfg(all(not(feature = "use-std"), feature = "alloc"))]
 extern crate alloc;
 
@@ -258,5 +266,13 @@ impl<T: Schema> Schema for alloc::vec::Vec<T> {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "Vec<T>",
         ty: &SdmTy::Seq(T::SCHEMA),
+    };
+}
+
+#[cfg(all(not(feature = "use-std"), feature = "alloc"))]
+impl Schema for alloc::string::String {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "String",
+        ty: &SdmTy::String,
     };
 }


### PR DESCRIPTION
Hi, we found a use for `Schema` in an `std` context, and the non-`heapless` String impl was missing.

Would you be okay with adding this impl?

BTW, I find that that this experimental feature is useful for `serde` in general, not just for postcard use.