### PR TITLE
PhantomData's T doesn't need MaxSize impl

### DIFF
--- a/src/max_size.rs
+++ b/src/max_size.rs
@@ -151,7 +151,7 @@ impl MaxSize for NonZeroUsize {
     const POSTCARD_MAX_SIZE: usize = usize::POSTCARD_MAX_SIZE;
 }
 
-impl<T: MaxSize> MaxSize for PhantomData<T> {
+impl<T> MaxSize for PhantomData<T> {
     const POSTCARD_MAX_SIZE: usize = 0;
 }
 


### PR DESCRIPTION
If PhantomData<T> is being used, it's very likely that the T isn't included in the data, and thus the MaxSize for it does not need to be derived.