### PR TITLE
Feat: Add IO traits support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ keywords = [
 ]
 documentation = "https://docs.rs/postcard/"
 
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
@@ -45,7 +44,11 @@ version = "0.2.3"
 default-features = false
 
 [dependencies.defmt]
-version = "0.3.0"
+version = "0.3"
+optional = true
+
+[dependencies.embedded-io]
+version = "0.4"
 optional = true
 
 [dependencies.postcard-derive]
@@ -62,9 +65,9 @@ version = "1.0.12"
 optional = true
 
 [features]
-default = ["heapless-cas"]
+default = ["heapless-cas", "use-std", "embedded-io"]
 
-use-std = ["serde/std", "alloc"]
+use-std = ["serde/std", "alloc", "embedded-io/std"]
 heapless-cas = ["heapless", "heapless/cas"]
 alloc = ["serde/alloc"]
 use-defmt = ["defmt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ version = "1.0.12"
 optional = true
 
 [features]
-default = ["heapless-cas", "use-std", "embedded-io"]
+default = ["heapless-cas", "use-std"]
 
 use-std = ["serde/std", "alloc", "embedded-io/std"]
 heapless-cas = ["heapless", "heapless/cas"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ version = "1.0.12"
 optional = true
 
 [features]
-default = ["heapless-cas", "use-std"]
+default = ["heapless-cas"]
 
 use-std = ["serde/std", "alloc", "embedded-io/std"]
 heapless-cas = ["heapless", "heapless/cas"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ default = ["heapless-cas"]
 
 use-std = ["serde/std", "alloc"]
 heapless-cas = ["heapless", "heapless/cas"]
-alloc = ["serde/alloc"]
+alloc = ["serde/alloc", "embedded-io/alloc"]
 use-defmt = ["defmt"]
 use-crc = ["crc", "paste"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ optional = true
 [features]
 default = ["heapless-cas"]
 
-use-std = ["serde/std", "alloc", "embedded-io/std"]
+use-std = ["serde/std", "alloc"]
 heapless-cas = ["heapless", "heapless/cas"]
 alloc = ["serde/alloc"]
 use-defmt = ["defmt"]

--- a/src/de/flavors.rs
+++ b/src/de/flavors.rs
@@ -329,16 +329,6 @@ pub mod io {
     }
 }
 
-// This is a terrible checksum implementation to make sure that we can effectively
-// use the deserialization flavor. This is kept as a test (and not published)
-// because an 8-bit checksum is not ACTUALLY useful for almost anything.
-//
-// You could certainly do something similar with a CRC32, cryptographic sig,
-// or something else
-#[cfg(test)]
-mod test {
-    use super::*;
-    use serde::{Deserialize, Serialize};
 ////////////////////////////////////////
 // CRC
 ////////////////////////////////////////

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -69,10 +69,10 @@ where
 
 /// Deserialize a message of type `T` from a [embedded_io::blocking::Read].
 #[cfg(feature = "embedded-io")]
-pub fn from_eio<'a, T, R>(val: (&'a mut R, &'a mut [u8])) -> Result<(T, (&'a mut R, &'a mut [u8]))>
+pub fn from_eio<'a, T, R>(val: (R, &'a mut [u8])) -> Result<(T, (R, &'a mut [u8]))>
 where
     T: Deserialize<'a>,
-    R: embedded_io::blocking::Read,
+    R: embedded_io::blocking::Read + 'a,
 {
     let flavor = flavors::io::eio::EIOReader::new(val.0, val.1);
     let mut deserializer = Deserializer::from_flavor(flavor);
@@ -82,13 +82,10 @@ where
 
 /// Deserialize a message of type `T` from a[std::io::Read].
 #[cfg(feature = "use-std")]
-pub fn from_io<'a, 'b, T, R>(
-    val: (&'a mut R, &'b mut [u8]),
-) -> Result<(T, (&'a mut R, &'b mut [u8]))>
+pub fn from_io<'a, T, R>(val: (R, &'a mut [u8])) -> Result<(T, (R, &'a mut [u8]))>
 where
-    'a: 'b,
-    T: Deserialize<'b>,
-    R: std::io::Read,
+    T: Deserialize<'a>,
+    R: std::io::Read + 'a,
 {
     let flavor = flavors::io::io::IOReader::new(val.0, val.1);
     let mut deserializer = Deserializer::from_flavor(flavor);

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -67,7 +67,7 @@ where
     Ok((t, deserializer.finalize()?))
 }
 
-/// Deserialize a message of type `T` from a[embedded_io::blocking::Write].
+/// Deserialize a message of type `T` from a [embedded_io::blocking::Read].
 #[cfg(feature = "embedded-io")]
 pub fn from_eio<'a, T, R>(val: (&'a mut R, &'a mut [u8])) -> Result<(T, (&'a mut R, &'a mut [u8]))>
 where
@@ -80,7 +80,7 @@ where
     Ok((t, deserializer.finalize()?))
 }
 
-/// Deserialize a message of type `T` from a[embedded_io::blocking::Write].
+/// Deserialize a message of type `T` from a[std::io::Read].
 #[cfg(feature = "use-std")]
 pub fn from_io<'a, 'b, T, R>(
     val: (&'a mut R, &'b mut [u8]),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -67,6 +67,35 @@ where
     Ok((t, deserializer.finalize()?))
 }
 
+/// Deserialize a message of type `T` from a[embedded_io::blocking::Write].
+#[cfg(feature = "embedded-io")]
+pub fn from_eio<'a, T, R>(val: (&'a mut R, &'a mut [u8])) -> Result<(T, (&'a mut R, &'a mut [u8]))>
+where
+    T: Deserialize<'a>,
+    R: embedded_io::blocking::Read,
+{
+    let flavor = flavors::io::eio::EIOReader::new(val.0, val.1);
+    let mut deserializer = Deserializer::from_flavor(flavor);
+    let t = T::deserialize(&mut deserializer)?;
+    Ok((t, deserializer.finalize()?))
+}
+
+/// Deserialize a message of type `T` from a[embedded_io::blocking::Write].
+#[cfg(feature = "use-std")]
+pub fn from_io<'a, 'b, T, R>(
+    val: (&'a mut R, &'b mut [u8]),
+) -> Result<(T, (&'a mut R, &'b mut [u8]))>
+where
+    'a: 'b,
+    T: Deserialize<'b>,
+    R: std::io::Read,
+{
+    let flavor = flavors::io::io::IOReader::new(val.0, val.1);
+    let mut deserializer = Deserializer::from_flavor(flavor);
+    let t = T::deserialize(&mut deserializer)?;
+    Ok((t, deserializer.finalize()?))
+}
+
 /// Conveniently deserialize a message of type `T` from a byte slice with a Crc. The unused portion (if any)
 /// of the byte slice is not returned.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,17 @@ pub use ser::{serialize_with_flavor, serializer::Serializer, to_slice, to_slice_
 #[cfg(feature = "heapless")]
 pub use ser::{to_vec, to_vec_cobs};
 
+#[cfg(feature = "embedded-io")]
+pub use ser::to_eio;
+
+#[cfg(feature = "embedded-io")]
+pub use de::from_eio;
+
 #[cfg(feature = "use-std")]
-pub use ser::{to_stdvec, to_stdvec_cobs};
+pub use ser::{to_io, to_stdvec, to_stdvec_cobs};
+
+#[cfg(feature = "use-std")]
+pub use de::from_io;
 
 #[cfg(feature = "alloc")]
 pub use ser::{to_allocvec, to_allocvec_cobs};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub use de::flavors as de_flavors;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
 pub use ser::flavors as ser_flavors;
-pub use ser::{serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs};
+pub use ser::{serialize_with_flavor, serializer::Serializer, to_extend, to_slice, to_slice_cobs};
 
 #[cfg(feature = "heapless")]
 pub use ser::{to_vec, to_vec_cobs};

--- a/tests/loopback.rs
+++ b/tests/loopback.rs
@@ -172,3 +172,77 @@ where
         assert_eq!(data, deserialized);
     }
 }
+
+#[cfg(feature = "use-std")]
+#[test]
+fn std_io_loopback() {
+    use postcard::from_io;
+    use postcard::to_io;
+
+    fn test_io<'a, 'de, T>(data: T, ser_rep: &'a [u8])
+    where
+        T: Serialize + DeserializeOwned + Eq + PartialEq + Debug,
+    {
+        let serialized: ::std::vec::Vec<u8> = vec![];
+        let ser = to_io(&data, serialized).unwrap();
+        assert_eq!(ser.len(), ser_rep.len());
+        assert_eq!(ser, ser_rep);
+        {
+            let mut buff = [0; 2048];
+            let x = ser.clone();
+            let deserialized: T = from_io((x.as_slice(), &mut buff)).unwrap().0;
+            assert_eq!(data, deserialized);
+        }
+    }
+
+    test_io(DataEnum::Sho(0x6969, 0x07), &[0x05, 0xE9, 0xD2, 0x01, 0x07]);
+    test_one(
+        BasicU8S {
+            st: 0xABCD,
+            ei: 0xFE,
+            sf: 0x1234_4321_ABCD_DCBA,
+            tt: 0xACAC_ACAC,
+        },
+        &[
+            0xCD, 0xD7, 0x02, 0xFE, 0xBA, 0xB9, 0xB7, 0xDE, 0x9A, 0xE4, 0x90, 0x9A, 0x12, 0xAC,
+            0xD9, 0xB2, 0xE5, 0x0A,
+        ],
+    );
+}
+
+#[cfg(all(feature = "embedded-io", feature = "alloc"))]
+#[test]
+fn std_eio_loopback() {
+    use postcard::from_eio;
+    use postcard::to_eio;
+
+    fn test_io<'a, 'de, T>(data: T, ser_rep: &'a [u8])
+    where
+        T: Serialize + DeserializeOwned + Eq + PartialEq + Debug,
+    {
+        let serialized: ::std::vec::Vec<u8> = vec![];
+        let ser = to_eio(&data, serialized).unwrap();
+        assert_eq!(ser.len(), ser_rep.len());
+        assert_eq!(ser, ser_rep);
+        {
+            let mut buff = [0; 2048];
+            let x = ser.clone();
+            let deserialized: T = from_eio((x.as_slice(), &mut buff)).unwrap().0;
+            assert_eq!(data, deserialized);
+        }
+    }
+
+    test_io(DataEnum::Sho(0x6969, 0x07), &[0x05, 0xE9, 0xD2, 0x01, 0x07]);
+    test_one(
+        BasicU8S {
+            st: 0xABCD,
+            ei: 0xFE,
+            sf: 0x1234_4321_ABCD_DCBA,
+            tt: 0xACAC_ACAC,
+        },
+        &[
+            0xCD, 0xD7, 0x02, 0xFE, 0xBA, 0xB9, 0xB7, 0xDE, 0x9A, 0xE4, 0x90, 0x9A, 0x12, 0xAC,
+            0xD9, 0xB2, 0xE5, 0x0A,
+        ],
+    );
+}

--- a/tests/loopback.rs
+++ b/tests/loopback.rs
@@ -196,7 +196,7 @@ fn std_io_loopback() {
     }
 
     test_io(DataEnum::Sho(0x6969, 0x07), &[0x05, 0xE9, 0xD2, 0x01, 0x07]);
-    test_one(
+    test_io(
         BasicU8S {
             st: 0xABCD,
             ei: 0xFE,
@@ -233,7 +233,7 @@ fn std_eio_loopback() {
     }
 
     test_io(DataEnum::Sho(0x6969, 0x07), &[0x05, 0xE9, 0xD2, 0x01, 0x07]);
-    test_one(
+    test_io(
         BasicU8S {
             st: 0xABCD,
             ei: 0xFE,


### PR DESCRIPTION
Added IO support using `embedded-io` and also supports std after #27. It does requires the user to pass a buffer for memory. Serialization uses `embedded-io` compatibility layer while deserialization reimplements it since I encountered lifetime issues

Couple points that I'm not sure with this implementation
- I'm not sure if it's `DeserializeUnexpectedEnd` is the right error to return when the IO fails, should an new internal error be created and used instead?
- Currently the pop function doesn't consume a byte on the provided buffer, is this an issue?

Comments are always appreciated!