### PR TITLE
Attempts at more terse `fixint` opt-ins

### DIFF
--- a/postcard-derive/src/all_fields_with.rs
+++ b/postcard-derive/src/all_fields_with.rs
@@ -1,0 +1,72 @@
+use proc_macro2::Span;
+use proc_macro2::TokenStream;
+use quote::*;
+use syn::punctuated::*;
+use syn::*;
+
+pub fn all_fields_with(
+    attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let gen = match modify_ast_to_add_with_attr(attr.into(), ast) {
+        Ok(g) => g,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    gen.into_token_stream().into()
+}
+
+fn modify_ast_to_add_with_attr(with: TokenStream, ast: DeriveInput) -> Result<impl ToTokens> {
+    let new_data: Data = match ast.data {
+        syn::Data::Struct(DataStruct {
+            struct_token,
+            fields,
+            semi_token,
+        }) => match fields {
+            fields => modify_fields_to_add_with_attr(with, struct_token, semi_token, fields)?,
+        },
+        data => data,
+    };
+    Ok(DeriveInput {
+        attrs: ast.attrs,
+        vis: ast.vis,
+        ident: ast.ident,
+        generics: ast.generics,
+        data: new_data,
+    })
+}
+
+pub fn modify_fields_to_add_with_attr(
+    with: TokenStream,
+    struct_token: syn::token::Struct,
+    semi_token: Option<syn::token::Semi>,
+    fields: Fields,
+) -> Result<Data> {
+    let mut fields = fields;
+    let attr = create_field_attribute(with);
+    fields.iter_mut().for_each(|f| f.attrs.push(attr.clone()));
+    Ok(Data::Struct(DataStruct {
+        struct_token,
+        fields: fields,
+        semi_token,
+    }))
+}
+
+fn create_field_attribute(with: TokenStream) -> Attribute {
+    let stream = quote!((with = #with));
+    let mut segments: Punctuated<PathSegment, Token![::]> = Punctuated::new();
+    segments.push(PathSegment {
+        ident: Ident::new("serde", Span::call_site()),
+        arguments: PathArguments::None,
+    });
+    Attribute {
+        pound_token: syn::token::Pound::default(),
+        style: syn::AttrStyle::Outer,
+        bracket_token: syn::token::Bracket::default(),
+        path: Path {
+            leading_colon: None,
+            segments,
+        },
+        tokens: stream,
+    }
+}

--- a/postcard-derive/src/lib.rs
+++ b/postcard-derive/src/lib.rs
@@ -1,3 +1,4 @@
+mod all_fields_with;
 mod max_size;
 mod schema;
 
@@ -11,4 +12,12 @@ pub fn derive_max_size(item: proc_macro::TokenStream) -> proc_macro::TokenStream
 #[proc_macro_derive(Schema)]
 pub fn derive_schema(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     schema::do_derive_schema(item)
+}
+
+#[proc_macro_attribute]
+pub fn all_fields_with(
+    attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    all_fields_with::all_fields_with(attr, input)
 }

--- a/src/fixint.rs
+++ b/src/fixint.rs
@@ -244,4 +244,48 @@ mod tests {
         let deserialized: DefinitelyBE = crate::from_bytes(serialized).unwrap();
         assert_eq!(deserialized, input);
     }
+
+    #[cfg(feature = "experimental-derive")]
+    #[test]
+    fn test_all_fields_with_be() {
+        #[postcard_derive::all_fields_with("crate::fixint::be")]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        pub struct DefinitelyBE {
+            x: u16,
+            y: u32,
+        }
+
+        let input = DefinitelyBE {
+            x: 0xABCD,
+            y: 0xEF123456,
+        };
+        let mut buf = [0; 32];
+        let serialized = crate::to_slice(&input, &mut buf).unwrap();
+        assert_eq!(serialized, &[0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56]);
+
+        let deserialized: DefinitelyBE = crate::from_bytes(serialized).unwrap();
+        assert_eq!(deserialized, input);
+    }
+
+    #[cfg(feature = "experimental-derive")]
+    #[test]
+    fn test_all_fields_with_le() {
+        #[postcard_derive::all_fields_with("crate::fixint::le")]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        pub struct DefinitelyLE {
+            x: u16,
+            y: u32,
+        }
+
+        let input = DefinitelyLE {
+            x: 0xABCD,
+            y: 0xEF123456,
+        };
+        let mut buf = [0; 32];
+        let serialized = crate::to_slice(&input, &mut buf).unwrap();
+        assert_eq!(serialized, &[0xCD, 0xAB, 0x56, 0x34, 0x12, 0xEF]);
+
+        let deserialized: DefinitelyLE = crate::from_bytes(serialized).unwrap();
+        assert_eq!(deserialized, input);
+    }
 }

--- a/src/fixint.rs
+++ b/src/fixint.rs
@@ -92,14 +92,28 @@ pub mod be {
 }
 
 #[doc(hidden)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct LE<T>(T);
 
 #[doc(hidden)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct BE<T>(T);
 
 macro_rules! impl_fixint {
     ($( $int:ty ),*) => {
         $(
+            impl From<LE<$int>> for $int {
+                fn from(val: LE<$int>) -> $int {
+                    val.0
+                }
+            }
+
+            impl From<$int> for LE<$int> {
+                fn from(val: $int) -> LE<$int> {
+                    LE(val)
+                }
+            }
+
             impl Serialize for LE<$int> {
                 #[inline]
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -119,6 +133,18 @@ macro_rules! impl_fixint {
                     <_ as Deserialize>::deserialize(deserializer)
                         .map(<$int>::from_le_bytes)
                         .map(Self)
+                }
+            }
+
+            impl From<BE<$int>> for $int {
+                fn from(val: BE<$int>) -> $int {
+                    val.0
+                }
+            }
+
+            impl From<$int> for BE<$int> {
+                fn from(val: $int) -> BE<$int> {
+                    BE(val)
                 }
             }
 
@@ -179,6 +205,38 @@ mod tests {
         }
 
         let input = DefinitelyBE { x: 0xABCD };
+        let mut buf = [0; 32];
+        let serialized = crate::to_slice(&input, &mut buf).unwrap();
+        assert_eq!(serialized, &[0xAB, 0xCD]);
+
+        let deserialized: DefinitelyBE = crate::from_bytes(serialized).unwrap();
+        assert_eq!(deserialized, input);
+    }
+
+    #[test]
+    fn test_little_endian_wrapper() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        pub struct DefinitelyLE {
+            x: crate::fixint::LE<u16>,
+        }
+
+        let input = DefinitelyLE { x: 0xABCD.into() };
+        let mut buf = [0; 32];
+        let serialized = crate::to_slice(&input, &mut buf).unwrap();
+        assert_eq!(serialized, &[0xCD, 0xAB]);
+
+        let deserialized: DefinitelyLE = crate::from_bytes(serialized).unwrap();
+        assert_eq!(deserialized, input);
+    }
+
+    #[test]
+    fn test_big_endian_wrapper() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        pub struct DefinitelyBE {
+            x: crate::fixint::BE<u16>,
+        }
+
+        let input = DefinitelyBE { x: 0xABCD.into() };
         let mut buf = [0; 32];
         let serialized = crate::to_slice(&input, &mut buf).unwrap();
         assert_eq!(serialized, &[0xAB, 0xCD]);


### PR DESCRIPTION
Two standalone commits here:
1. An attempt at just making the field attribute a bit more terse, but I think this is basically just the 'wrapper' y'all had before? Still have to annotate every field, plus now I have to use `into()` everywhere. Diff for my project looks like this:
```diff
diff --git a/device/src/messaging/packets.rs b/device/src/messaging/packets.rs
index 0d22758..02c80ab 100644
--- a/device/src/messaging/packets.rs
+++ b/device/src/messaging/packets.rs
@@ -1,4 +1,5 @@
 use arrayref::array_ref;
+use postcard::fixint::*;
 use serde::{Deserialize, Serialize};
 
 use super::wrapper::MAX_MESSAGE_SIZE;
@@ -34,10 +35,8 @@ pub struct RequestControllerCount {}
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct RequestControllerCountResponse {
-    #[serde(with = "postcard::fixint::le")]
-    packet_id: u32,
-    #[serde(with = "postcard::fixint::le")]
-    controller_count: u32,
+    packet_id: LE<u32>,
+    controller_count: LE<u32>,
 }
 
 impl Handler<RequestControllerCountResponse> for RequestControllerCount {
@@ -48,8 +47,8 @@ impl Handler<RequestControllerCountResponse> for RequestControllerCount {
 
     fn handle(&self, controller: &Controller) -> RequestControllerCountResponse {
         RequestControllerCountResponse {
-            packet_id: 0,
-            controller_count: controller.controller_count(),
+            packet_id: 0.into(),
+            controller_count: controller.controller_count().into(),
         }
     }
 }
```

2. A macro based on this post I found: https://users.rust-lang.org/t/proc-macro-attribute-to-add-a-serde-deserialize-with-to-every-field-in-a-struct/71231
This seems... fragile. I did find a serde issue/PR where they wanted to do something similar, but it's old, not very active, and had a lot of feedback I didn't quite grok. This does manage to achieve exactly what I was looking for though, so I have a copy in my own codebase that I'm proceeding with. Changes to my project look like this:
```diff
diff --git a/device/src/messaging/packets.rs b/device/src/messaging/packets.rs
index 02c80ab..b7bdeb9 100644
--- a/device/src/messaging/packets.rs
+++ b/device/src/messaging/packets.rs
@@ -1,5 +1,5 @@
 use arrayref::array_ref;
-use postcard::fixint::*;
+use corsairust_macros::all_fields_with;
 use serde::{Deserialize, Serialize};
 
 use super::wrapper::MAX_MESSAGE_SIZE;
@@ -33,10 +33,11 @@ pub trait Handler<R: Serialize> {
 
 pub struct RequestControllerCount {}
 
+#[all_fields_with("postcard::fixint::le")]
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct RequestControllerCountResponse {
-    packet_id: LE<u32>,
-    controller_count: LE<u32>,
+    packet_id: u32,
+    controller_count: u32,
 }
 
 impl Handler<RequestControllerCountResponse> for RequestControllerCount {
@@ -47,8 +48,8 @@ impl Handler<RequestControllerCountResponse> for RequestControllerCount {
 
     fn handle(&self, controller: &Controller) -> RequestControllerCountResponse {
         RequestControllerCountResponse {
-            packet_id: 0.into(),
-            controller_count: controller.controller_count().into(),
+            packet_id: 0,
+            controller_count: controller.controller_count(),
         }
     }
 }
```

There's probably a better way to make this stuff happen at the library level? Like ideally `use postcard::fixint::le::*` would just magically configure it for your whole module, but that magic is beyond me still :smiling_face_with_tear: 