### PR TITLE
improved documentation of the cobs decoding

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -20,6 +20,8 @@ where
 
 /// Deserialize a message of type `T` from a cobs-encoded byte slice. The
 /// unused portion (if any) of the byte slice is not returned.
+/// The used portion of the input slice is modified during deserialization (even if an error is returned). 
+/// Therefore, if this is not desired, pass a clone of the original slice.
 pub fn from_bytes_cobs<'a, T>(s: &'a mut [u8]) -> Result<T>
 where
     T: Deserialize<'a>,
@@ -29,7 +31,9 @@ where
 }
 
 /// Deserialize a message of type `T` from a cobs-encoded byte slice. The
-/// unused portion (if any) of the byte slice is returned for further usage
+/// unused portion (if any) of the byte slice is returned for further usage.
+/// The used portion of the input slice is modified during deserialization (even if an error is returned). 
+/// Therefore, if this is not desired, pass a clone of the original slice.
 pub fn take_from_bytes_cobs<'a, T>(s: &'a mut [u8]) -> Result<(T, &'a mut [u8])>
 where
     T: Deserialize<'a>,


### PR DESCRIPTION
I believe that the modification of the input buffer by the cobs decoding functions is not expected as a user of the library, as it requires you to copy the input buffer every time you call it. In postcard, this does not happen with the non-cobs serde functions. 

I consider that by noting this fact in the documentation, other users might be able to realise it earlier and spend less time debugging as it happened to me.