### PR TITLE
Introduces CRCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ optional = true
 
 [dependencies.paste]
 version = "1.0.12"
+optional = true
 
 [features]
 default = ["heapless-cas"]
@@ -66,7 +67,7 @@ use-std = ["serde/std", "alloc"]
 heapless-cas = ["heapless", "heapless/cas"]
 alloc = ["serde/alloc"]
 use-defmt = ["defmt"]
-use-crc = ["crc"]
+use-crc = ["crc", "paste"]
 
 # Experimental features!
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ optional = true
 version = "3.0.1"
 optional = true
 
+[dependencies.paste]
+version = "1.0.12"
+
 [features]
 default = ["heapless-cas"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ path = "./postcard-derive"
 version = "0.1.1"
 optional = true
 
+[dependencies.crc]
+version = "3.0.1"
+optional = true
+
 [features]
 default = ["heapless-cas"]
 
@@ -59,6 +63,7 @@ use-std = ["serde/std", "alloc"]
 heapless-cas = ["heapless", "heapless/cas"]
 alloc = ["serde/alloc"]
 use-defmt = ["defmt"]
+use-crc = ["crc"]
 
 # Experimental features!
 #

--- a/src/de/flavors.rs
+++ b/src/de/flavors.rs
@@ -270,7 +270,7 @@ pub mod crc {
 
                     /// Deserialize a message of type `T` from a byte slice with a Crc. The unused portion (if any)
                     /// of the byte slice is not returned.
-                    pub fn [<from_bytes_ $int>]<'a, T>(s: &'a [u8], digest: Digest<'a, u32>) -> Result<T>
+                    pub fn [<from_bytes_ $int>]<'a, T>(s: &'a [u8], digest: Digest<'a, $int>) -> Result<T>
                     where
                         T: Deserialize<'a>,
                     {
@@ -283,7 +283,7 @@ pub mod crc {
 
                     /// Deserialize a message of type `T` from a byte slice with a Crc. The unused portion (if any)
                     /// of the byte slice is returned for further usage
-                    pub fn [<take_from_bytes_ $int>]<'a, T>(s: &'a [u8], digest: Digest<'a, u32>) -> Result<(T, &'a [u8])>
+                    pub fn [<take_from_bytes_ $int>]<'a, T>(s: &'a [u8], digest: Digest<'a, $int>) -> Result<(T, &'a [u8])>
                     where
                         T: Deserialize<'a>,
                     {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -20,7 +20,7 @@ where
 
 /// Deserialize a message of type `T` from a cobs-encoded byte slice. The
 /// unused portion (if any) of the byte slice is not returned.
-/// The used portion of the input slice is modified during deserialization (even if an error is returned). 
+/// The used portion of the input slice is modified during deserialization (even if an error is returned).
 /// Therefore, if this is not desired, pass a clone of the original slice.
 pub fn from_bytes_cobs<'a, T>(s: &'a mut [u8]) -> Result<T>
 where
@@ -32,7 +32,7 @@ where
 
 /// Deserialize a message of type `T` from a cobs-encoded byte slice. The
 /// unused portion (if any) of the byte slice is returned for further usage.
-/// The used portion of the input slice is modified during deserialization (even if an error is returned). 
+/// The used portion of the input slice is modified during deserialization (even if an error is returned).
 /// Therefore, if this is not desired, pass a clone of the original slice.
 pub fn take_from_bytes_cobs<'a, T>(s: &'a mut [u8]) -> Result<(T, &'a mut [u8])>
 where
@@ -66,6 +66,22 @@ where
     let t = T::deserialize(&mut deserializer)?;
     Ok((t, deserializer.finalize()?))
 }
+
+/// Conveniently deserialize a message of type `T` from a byte slice with a Crc. The unused portion (if any)
+/// of the byte slice is not returned.
+///
+/// See the `de_flavors::crc` module for the complete set of functions.
+/// 
+#[cfg(feature = "use-crc")]
+pub use flavors::crc::from_bytes_u32 as from_bytes_crc32;
+
+/// Conveniently deserialize a message of type `T` from a byte slice with a Crc. The unused portion (if any)
+/// of the byte slice is returned for further usage
+///
+/// See the `de_flavors::crc` module for the complete set of functions.
+/// 
+#[cfg(feature = "use-crc")]
+pub use flavors::crc::take_from_bytes_u32 as take_from_bytes_crc32;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,21 @@ pub use ser::{to_stdvec, to_stdvec_cobs};
 #[cfg(feature = "alloc")]
 pub use ser::{to_allocvec, to_allocvec_cobs};
 
+#[cfg(feature = "use-crc")]
+pub use {
+    de::{from_bytes_crc32, take_from_bytes_crc32},
+    ser::to_slice_crc32,
+};
+
+#[cfg(all(feature = "use-crc", feature = "heapless"))]
+pub use ser::to_vec_crc32;
+
+#[cfg(all(feature = "use-crc", feature = "use-std"))]
+pub use ser::to_stdvec_crc32;
+
+#[cfg(all(feature = "use-crc", feature = "alloc"))]
+pub use ser::to_allocvec_crc32;
+
 #[cfg(test)]
 mod test {
     #[test]

--- a/src/ser/flavors.rs
+++ b/src/ser/flavors.rs
@@ -495,7 +495,7 @@ pub mod crc {
                     pub fn [<to_slice_ $int>]<'a, 'b, T>(
                         value: &'b T,
                         buf: &'a mut [u8],
-                        digest: Digest<'a, u32>,
+                        digest: Digest<'a, $int>,
                     ) -> Result<&'a mut [u8]>
                     where
                         T: Serialize + ?Sized,
@@ -509,7 +509,7 @@ pub mod crc {
                     #[cfg(feature = "heapless")]
                     pub fn [<to_vec_ $int>]<'a, T, const B: usize>(
                         value: &T,
-                        digest: Digest<'a, u32>,
+                        digest: Digest<'a, $int>,
                     ) -> Result<heapless::Vec<u8, B>>
                     where
                         T: Serialize + ?Sized,
@@ -522,7 +522,7 @@ pub mod crc {
                     /// Serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
                     /// data followed by a CRC. The CRC bytes are included in the output `Vec`.
                     #[cfg(feature = "alloc")]
-                    pub fn [<to_allocvec_ $int>]<'a, T>(value: &T, digest: Digest<'a, u32>) -> Result<alloc::vec::Vec<u8>>
+                    pub fn [<to_allocvec_ $int>]<'a, T>(value: &T, digest: Digest<'a, $int>) -> Result<alloc::vec::Vec<u8>>
                     where
                         T: Serialize + ?Sized,
                     {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -237,6 +237,107 @@ where
     )
 }
 
+/// Conveniently serialize a `T` to the given slice, with the resulting slice containing
+/// data followed by a 32-bit CRC. The CRC bytes are included in the output buffer.
+///
+/// When successful, this function returns the slice containing the
+/// serialized and encoded message.
+///
+/// ## Example
+///
+/// ```rust
+/// use crc::{Crc, CRC_32_ISCSI};
+///
+/// let mut buf = [0; 9];
+///
+/// let data: &[u8] = &[0x01, 0x00, 0x20, 0x30];
+/// let crc = Crc::<u32>::new(&CRC_32_ISCSI);
+/// let used = postcard::to_slice_crc32(data, &mut buf, crc.digest()).unwrap();
+/// assert_eq!(used, &[0x04, 0x01, 0x00, 0x20, 0x30, 0x8E, 0xC8, 0x1A, 0x37]);
+/// ```
+///
+/// See the `ser_flavors::crc` module for the complete set of functions.
+/// 
+#[cfg(feature = "use-crc")]
+pub use flavors::crc::to_slice_u32 as to_slice_crc32;
+
+/// Conveniently serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
+/// data followed by a 32-bit  CRC. The CRC bytes are included in the output `Vec`.
+/// Requires the (default) `heapless` feature.
+///
+/// ## Example
+///
+/// ```rust
+/// use crc::{Crc, CRC_32_ISCSI};
+/// use heapless::Vec;
+/// use core::ops::Deref;
+///
+/// // NOTE: postcard handles `&[u8]` and `&[u8; N]` differently.
+/// let data: &[u8] = &[0x01u8, 0x00, 0x20, 0x30];
+/// let crc = Crc::<u32>::new(&CRC_32_ISCSI);
+/// let ser: Vec<u8, 32> = postcard::to_vec_crc32(data, crc.digest()).unwrap();
+/// assert_eq!(ser.deref(), &[0x04, 0x01, 0x00, 0x20, 0x30, 0x8E, 0xC8, 0x1A, 0x37]);
+///
+/// let data: &[u8; 4] = &[0x01u8, 0x00, 0x20, 0x30];
+/// let ser: Vec<u8, 32> = postcard::to_vec_crc32(data, crc.digest()).unwrap();
+/// assert_eq!(ser.deref(), &[0x01, 0x00, 0x20, 0x30, 0xCC, 0x4B, 0x4A, 0xDA]);
+/// ```
+///
+/// See the `ser_flavors::crc` module for the complete set of functions.
+/// 
+#[cfg(all(feature = "use-crc", feature = "heapless"))]
+pub use flavors::crc::to_vec_u32 as to_vec_crc32;
+
+/// Conveniently serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
+/// data followed by a 32-bit  CRC. The CRC bytes are included in the output `Vec`.
+///
+/// ## Example
+///
+/// ```rust
+/// use crc::{Crc, CRC_32_ISCSI};
+/// use core::ops::Deref;
+///
+/// // NOTE: postcard handles `&[u8]` and `&[u8; N]` differently.
+/// let data: &[u8] = &[0x01u8, 0x00, 0x20, 0x30];
+/// let crc = Crc::<u32>::new(&CRC_32_ISCSI);
+/// let ser: Vec<u8> = postcard::to_stdvec_crc32(data, crc.digest()).unwrap();
+/// assert_eq!(ser.deref(), &[0x04, 0x01, 0x00, 0x20, 0x30, 0x8E, 0xC8, 0x1A, 0x37]);
+///
+/// let data: &[u8; 4] = &[0x01u8, 0x00, 0x20, 0x30];
+/// let ser: Vec<u8> = postcard::to_stdvec_crc32(data, crc.digest()).unwrap();
+/// assert_eq!(ser.deref(), &[0x01, 0x00, 0x20, 0x30, 0xCC, 0x4B, 0x4A, 0xDA]);
+/// ```
+///
+/// See the `ser_flavors::crc` module for the complete set of functions.
+/// 
+#[cfg(all(feature = "use-crc", feature = "use-std"))]
+pub use flavors::crc::to_allocvec_u32 as to_stdvec_crc32;
+
+/// Conveniently serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
+/// data followed by a 32-bit  CRC. The CRC bytes are included in the output `Vec`.
+///
+/// ## Example
+///
+/// ```rust
+/// use crc::{Crc, CRC_32_ISCSI};
+/// use core::ops::Deref;
+///
+/// // NOTE: postcard handles `&[u8]` and `&[u8; N]` differently.
+/// let data: &[u8] = &[0x01u8, 0x00, 0x20, 0x30];
+/// let crc = Crc::<u32>::new(&CRC_32_ISCSI);
+/// let ser: Vec<u8> = postcard::to_allocvec_crc32(data, crc.digest()).unwrap();
+/// assert_eq!(ser.deref(), &[0x04, 0x01, 0x00, 0x20, 0x30, 0x8E, 0xC8, 0x1A, 0x37]);
+///
+/// let data: &[u8; 4] = &[0x01u8, 0x00, 0x20, 0x30];
+/// let ser: Vec<u8> = postcard::to_allocvec_crc32(data, crc.digest()).unwrap();
+/// assert_eq!(ser.deref(), &[0x01, 0x00, 0x20, 0x30, 0xCC, 0x4B, 0x4A, 0xDA]);
+/// ```
+///
+/// See the `ser_flavors::crc` module for the complete set of functions.
+///
+#[cfg(all(feature = "use-crc", feature = "alloc"))]
+pub use flavors::crc::to_allocvec_u32 as to_allocvec_crc32;
+
 /// `serialize_with_flavor()` has three generic parameters, `T, F, O`.
 ///
 /// * `T`: This is the type that is being serialized

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -1,29 +1,19 @@
 #[test]
-#[cfg(feature = "crc")]
+#[cfg(feature = "use-crc")]
 fn test_crc() {
     use crc::{Crc, CRC_32_ISCSI};
-    use postcard::{
-        de_flavors::{crc::CrcModifier as DeCrcModifier, Slice as DeSlice},
-        ser_flavors::{crc::CrcModifier as SerCrcModifier, Slice as SerSlice},
-        serialize_with_flavor, Deserializer,
-    };
-    use serde::de::Deserialize;
 
     let data: &[u8] = &[0x01, 0x00, 0x20, 0x30];
     let buffer = &mut [0u8; 32];
     let crc = Crc::<u32>::new(&CRC_32_ISCSI);
     let digest = crc.digest();
-    let res =
-        serialize_with_flavor(data, SerCrcModifier::new(SerSlice::new(buffer), digest)).unwrap();
-
+    let res = postcard::to_slice_crc32(data, buffer, digest).unwrap();
     assert_eq!(res, &[0x04, 0x01, 0x00, 0x20, 0x30, 0x8E, 0xC8, 0x1A, 0x37]);
 
     let digest = crc.digest();
-    let flav = DeCrcModifier::new(DeSlice::new(&res), digest);
-    let mut deserializer = Deserializer::from_flavor(flav);
-    let res = <[u8; 5]>::deserialize(&mut deserializer).unwrap();
+    let res = postcard::take_from_bytes_crc32::<[u8; 5]>(&res, digest).unwrap();
 
-    assert_eq!(res, [0x04, 0x01, 0x00, 0x20, 0x30]);
-
-    assert_eq!(deserializer.finalize().unwrap(), &[0u8; 0]);
+    let expected_bytes = [0x04, 0x01, 0x00, 0x20, 0x30];
+    let remaining_bytes = [];
+    assert_eq!(res, (expected_bytes, remaining_bytes.as_slice()));
 }

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -1,0 +1,29 @@
+#[test]
+#[cfg(feature = "crc")]
+fn test_crc() {
+    use crc::{Crc, CRC_32_ISCSI};
+    use postcard::{
+        de_flavors::{crc::CrcModifier as DeCrcModifier, Slice as DeSlice},
+        ser_flavors::{crc::CrcModifier as SerCrcModifier, Slice as SerSlice},
+        serialize_with_flavor, Deserializer,
+    };
+    use serde::de::Deserialize;
+
+    let data: &[u8] = &[0x01, 0x00, 0x20, 0x30];
+    let buffer = &mut [0u8; 32];
+    let crc = Crc::<u32>::new(&CRC_32_ISCSI);
+    let digest = crc.digest();
+    let res =
+        serialize_with_flavor(data, SerCrcModifier::new(SerSlice::new(buffer), digest)).unwrap();
+
+    assert_eq!(res, &[0x04, 0x01, 0x00, 0x20, 0x30, 0x8E, 0xC8, 0x1A, 0x37]);
+
+    let digest = crc.digest();
+    let flav = DeCrcModifier::new(DeSlice::new(&res), digest);
+    let mut deserializer = Deserializer::from_flavor(flav);
+    let res = <[u8; 5]>::deserialize(&mut deserializer).unwrap();
+
+    assert_eq!(res, [0x04, 0x01, 0x00, 0x20, 0x30]);
+
+    assert_eq!(deserializer.finalize().unwrap(), &[0u8; 0]);
+}

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -17,3 +17,23 @@ fn test_crc() {
     let remaining_bytes = [];
     assert_eq!(res, (expected_bytes, remaining_bytes.as_slice()));
 }
+
+#[test]
+#[cfg(feature = "use-crc")]
+fn test_crc_8() {
+    use crc::{Crc, CRC_8_SMBUS};
+
+    let data: &[u8] = &[0x01, 0x00, 0x20, 0x30];
+    let buffer = &mut [0u8; 32];
+    let crc = Crc::<u8>::new(&CRC_8_SMBUS);
+    let digest = crc.digest();
+    let res = postcard::ser_flavors::crc::to_slice_u8(data, buffer, digest).unwrap();
+    assert_eq!(res, &[0x04, 0x01, 0x00, 0x20, 0x30, 167]);
+
+    let digest = crc.digest();
+    let res = postcard::de_flavors::crc::take_from_bytes_u8::<[u8; 5]>(&res, digest).unwrap();
+
+    let expected_bytes = [0x04, 0x01, 0x00, 0x20, 0x30];
+    let remaining_bytes = [];
+    assert_eq!(res, (expected_bytes, remaining_bytes.as_slice()));
+}


### PR DESCRIPTION
A `crc` feature has been added that brings in the `crc` crate and a new `CrcModifier` flavour. This modifier flavour is similar to the COBS implementation in how it wraps another flavour.

Convenience functions for serde are also introduced.

TODO:

* [x] Provide serialisation
* [x] Provide deserialisation