### PR TITLE
Format with rustfmt to eliminate trailing whitespaces

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -71,7 +71,7 @@ where
 /// of the byte slice is not returned.
 ///
 /// See the `de_flavors::crc` module for the complete set of functions.
-/// 
+///
 #[cfg(feature = "use-crc")]
 pub use flavors::crc::from_bytes_u32 as from_bytes_crc32;
 
@@ -79,7 +79,7 @@ pub use flavors::crc::from_bytes_u32 as from_bytes_crc32;
 /// of the byte slice is returned for further usage
 ///
 /// See the `de_flavors::crc` module for the complete set of functions.
-/// 
+///
 #[cfg(feature = "use-crc")]
 pub use flavors::crc::take_from_bytes_u32 as take_from_bytes_crc32;
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -257,7 +257,7 @@ where
 /// ```
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
-/// 
+///
 #[cfg(feature = "use-crc")]
 pub use flavors::crc::to_slice_u32 as to_slice_crc32;
 
@@ -284,7 +284,7 @@ pub use flavors::crc::to_slice_u32 as to_slice_crc32;
 /// ```
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
-/// 
+///
 #[cfg(all(feature = "use-crc", feature = "heapless"))]
 pub use flavors::crc::to_vec_u32 as to_vec_crc32;
 
@@ -309,7 +309,7 @@ pub use flavors::crc::to_vec_u32 as to_vec_crc32;
 /// ```
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
-/// 
+///
 #[cfg(all(feature = "use-crc", feature = "use-std"))]
 pub use flavors::crc::to_allocvec_u32 as to_stdvec_crc32;
 


### PR DESCRIPTION
Generated by `cargo fmt`