### PR TITLE
Fix documentation of re-exports that have dedicated doc comment

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -71,17 +71,28 @@ where
 /// of the byte slice is not returned.
 ///
 /// See the `de_flavors::crc` module for the complete set of functions.
-/// 
 #[cfg(feature = "use-crc")]
-pub use flavors::crc::from_bytes_u32 as from_bytes_crc32;
+pub fn from_bytes_crc32<'a, T>(s: &'a [u8], digest: crc::Digest<'a, u32>) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    flavors::crc::from_bytes_u32(s, digest)
+}
 
 /// Conveniently deserialize a message of type `T` from a byte slice with a Crc. The unused portion (if any)
 /// of the byte slice is returned for further usage
 ///
 /// See the `de_flavors::crc` module for the complete set of functions.
-/// 
 #[cfg(feature = "use-crc")]
-pub use flavors::crc::take_from_bytes_u32 as take_from_bytes_crc32;
+pub fn take_from_bytes_crc32<'a, T>(
+    s: &'a [u8],
+    digest: crc::Digest<'a, u32>,
+) -> Result<(T, &'a [u8])>
+where
+    T: Deserialize<'a>,
+{
+    flavors::crc::take_from_bytes_u32(s, digest)
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -170,7 +170,12 @@ where
 /// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
 /// ```
 #[cfg(feature = "use-std")]
-pub use to_allocvec as to_stdvec;
+pub fn to_stdvec<T>(value: &T) -> Result<std::vec::Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    to_allocvec(value)
+}
 
 /// Serialize and COBS encode a `T` to a `std::vec::Vec<u8>`. Requires the `use-std` feature.
 ///
@@ -188,7 +193,12 @@ pub use to_allocvec as to_stdvec;
 /// assert_eq!(ser.as_slice(), &[0x05, 0x03, b'H', b'i', b'!', 0x00]);
 /// ```
 #[cfg(feature = "use-std")]
-pub use to_allocvec_cobs as to_stdvec_cobs;
+pub fn to_stdvec_cobs<T>(value: &T) -> Result<std::vec::Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    to_allocvec_cobs(value)
+}
 
 /// Serialize a `T` to an `alloc::vec::Vec<u8>`. Requires the `alloc` feature.
 ///
@@ -257,9 +267,17 @@ where
 /// ```
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
-/// 
 #[cfg(feature = "use-crc")]
-pub use flavors::crc::to_slice_u32 as to_slice_crc32;
+pub fn to_slice_crc32<'a, 'b, T>(
+    value: &'b T,
+    buf: &'a mut [u8],
+    digest: crc::Digest<'a, u32>,
+) -> Result<&'a mut [u8]>
+where
+    T: Serialize + ?Sized,
+{
+    flavors::crc::to_slice_u32(value, buf, digest)
+}
 
 /// Conveniently serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
 /// data followed by a 32-bit  CRC. The CRC bytes are included in the output `Vec`.
@@ -284,9 +302,16 @@ pub use flavors::crc::to_slice_u32 as to_slice_crc32;
 /// ```
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
-/// 
 #[cfg(all(feature = "use-crc", feature = "heapless"))]
-pub use flavors::crc::to_vec_u32 as to_vec_crc32;
+pub fn to_vec_crc32<'a, T, const B: usize>(
+    value: &T,
+    digest: crc::Digest<'a, u32>,
+) -> Result<heapless::Vec<u8, B>>
+where
+    T: Serialize + ?Sized,
+{
+    flavors::crc::to_vec_u32(value, digest)
+}
 
 /// Conveniently serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
 /// data followed by a 32-bit  CRC. The CRC bytes are included in the output `Vec`.
@@ -309,9 +334,13 @@ pub use flavors::crc::to_vec_u32 as to_vec_crc32;
 /// ```
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
-/// 
 #[cfg(all(feature = "use-crc", feature = "use-std"))]
-pub use flavors::crc::to_allocvec_u32 as to_stdvec_crc32;
+pub fn to_stdvec_crc32<'a, T>(value: &T, digest: crc::Digest<'a, u32>) -> Result<std::vec::Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    flavors::crc::to_allocvec_u32(value, digest)
+}
 
 /// Conveniently serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
 /// data followed by a 32-bit  CRC. The CRC bytes are included in the output `Vec`.
@@ -334,9 +363,16 @@ pub use flavors::crc::to_allocvec_u32 as to_stdvec_crc32;
 /// ```
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
-///
 #[cfg(all(feature = "use-crc", feature = "alloc"))]
-pub use flavors::crc::to_allocvec_u32 as to_allocvec_crc32;
+pub fn to_allocvec_crc32<'a, T>(
+    value: &T,
+    digest: crc::Digest<'a, u32>,
+) -> Result<alloc::vec::Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    flavors::crc::to_allocvec_u32(value, digest)
+}
 
 /// `serialize_with_flavor()` has three generic parameters, `T, F, O`.
 ///


### PR DESCRIPTION
Fixes #65.

Rustdoc's behavior for doc attributes on `pub use` items is to concatenate the attributes from the `pub use` with the attributes from the original item. It looks like that is not what was intended in the documentation in postcard.

In this PR I have converted all `pub use` that had `///` doc comments on them, into functions. This way they get to have their own self-contained documentation.

**Before:**

<img src="https://github.com/jamesmunns/postcard/assets/1940490/e0170a89-00f9-4148-85a3-bdd6213a5b11" width="500">

**After:**

<img src="https://github.com/jamesmunns/postcard/assets/1940490/51985ae0-f451-4581-832e-f93ca3707edc" width="500">