### PR TITLE
Minor: Fix off-by-one in varint size calculation

### DIFF
--- a/src/varint.rs
+++ b/src/varint.rs
@@ -6,10 +6,10 @@ pub const fn varint_max<T: Sized>() -> usize {
     // How many data bits do we need for this type?
     let bits = core::mem::size_of::<T>() * BITS_PER_BYTE;
 
-    // We add (BITS_PER_BYTE - 1), to ensure any integer divisions
+    // We add (BITS_PER_VARINT_BYTE - 1), to ensure any integer divisions
     // with a remainder will always add exactly one full byte, but
     // an evenly divided number of bits will be the same
-    let roundup_bits = bits + (BITS_PER_BYTE - 1);
+    let roundup_bits = bits + (BITS_PER_VARINT_BYTE - 1);
 
     // Apply division, using normal "round down" integer division
     roundup_bits / BITS_PER_VARINT_BYTE


### PR DESCRIPTION
I was reading through the varint implementation in postcard to sanity-check one of my own implementations, and I spotted a mistake in the code that calculates the maximum number of varint bytes an integer datatype can take.

The old version adds 7 instead of 6, so instead of the behaviour documented in the comment it would overestimate the number of varint bytes required by one for datatypes whole size is a multiple of 7 bits. Since there are thankfully none among the common integer datatypes, the behaviour is correct both before and after the change.