### PR TITLE
Re-export used crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,14 @@ pub mod fixint;
 mod ser;
 mod varint;
 
+pub use cobs;
+#[cfg(feature = "crc")]
+pub use crc;
+pub use heapless;
+#[cfg(feature = "crc")]
+pub use paste;
+pub use serde;
+
 // Still experimental! Don't make pub pub.
 pub(crate) mod max_size;
 pub(crate) mod schema;


### PR DESCRIPTION
Fixes below errors (mismatched crate versions):

```
  Compiling shared v0.1.0 (/Users/lkostka/workspace/gbot/shared)
error[E0308]: mismatched types
  --> shared/src/lib.rs:39:31
   |
39 |         let out: Vec<u8, 4> = postcard::to_vec(&axis).unwrap();
   |                  ----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<u8, 4>`, found `Vec<u8, _>`
   |                  |
   |                  expected due to this
   |
   = note: `heapless::vec::Vec<u8, _>` and `heapless::Vec<u8, 4>` have similar names, but are actually distinct types
note: `heapless::vec::Vec<u8, _>` is defined in crate `heapless`
  --> /Users/lkostka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/heapless-0.7.16/src/vec.rs:36:1
   |
36 | pub struct Vec<T, const N: usize> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: `heapless::Vec<u8, 4>` is defined in crate `heapless`
  --> /Users/lkostka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/heapless-0.8.0/src/vec.rs:32:1
   |
32 | pub struct Vec<T, const N: usize> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: perhaps two different versions of crate `heapless` are being used?

For more information about this error, try `rustc --explain E0308`.
```