### PR TITLE
#118 Add support for latest embedded-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard"
-version = "1.0.8"
+version = "1.0.9"
 authors = ["James Munns <james@onevariable.com>"]
 edition = "2018"
 readme = "README.md"
@@ -47,8 +47,14 @@ default-features = false
 version = "0.3"
 optional = true
 
-[dependencies.embedded-io]
+[dependencies.embedded-io-04]
+package = "embedded-io"
 version = "0.4"
+optional = true
+
+[dependencies.embedded-io-06]
+package = "embedded-io"
+version = "0.6"
 optional = true
 
 [dependencies.postcard-derive]
@@ -67,9 +73,17 @@ optional = true
 [features]
 default = ["heapless-cas"]
 
+# Enables support for `embedded-io` traits
+# This feature will track the latest `embedded-io` when major releases are made
+embedded-io = ["dep:embedded-io-04"]
+
+# Specific versions of `embedded-io` can be selected through the features below
+embedded-io-04 = ["dep:embedded-io-04"]
+embedded-io-06 = ["dep:embedded-io-06"]
+
 use-std = ["serde/std", "alloc"]
 heapless-cas = ["heapless", "heapless/cas"]
-alloc = ["serde/alloc", "embedded-io/alloc"]
+alloc = ["serde/alloc", "embedded-io-04?/alloc", "embedded-io-06?/alloc"]
 use-defmt = ["defmt"]
 use-crc = ["crc", "paste"]
 

--- a/src/de/flavors.rs
+++ b/src/de/flavors.rs
@@ -163,8 +163,12 @@ impl<'de> Flavor<'de> for Slice<'de> {
     }
 }
 
-/// Support for [std::io] or [embedded-io] traits
-#[cfg(any(feature = "embedded-io", feature = "use-std"))]
+/// Support for [std::io] or `embedded-io` traits
+#[cfg(any(
+    feature = "embedded-io-04",
+    feature = "embedded-io-06",
+    feature = "use-std"
+))]
 pub mod io {
     use crate::{Error, Result};
     use core::marker::PhantomData;
@@ -206,17 +210,17 @@ pub mod io {
         }
     }
 
-    /// Support for [embedded_io] traits
-    #[cfg(feature = "embedded-io")]
+    /// Support for [`embedded_io`](crate::eio::embedded_io) traits
+    #[cfg(any(feature = "embedded-io-04", feature = "embedded-io-06"))]
     pub mod eio {
         use super::super::Flavor;
         use super::SlidingBuffer;
         use crate::{Error, Result};
 
-        /// Wrapper over a [embedded_io::blocking::Read] and a sliding buffer to implement the [Flavor] trait
+        /// Wrapper over a [`embedded_io`](crate::eio::embedded_io)::[`Read`](crate::eio::Read) and a sliding buffer to implement the [Flavor] trait
         pub struct EIOReader<'de, T>
         where
-            T: embedded_io::blocking::Read,
+            T: crate::eio::Read,
         {
             reader: T,
             buff: SlidingBuffer<'de>,
@@ -224,7 +228,7 @@ pub mod io {
 
         impl<'de, T> EIOReader<'de, T>
         where
-            T: embedded_io::blocking::Read,
+            T: crate::eio::Read,
         {
             pub(crate) fn new(reader: T, buff: &'de mut [u8]) -> Self {
                 Self {
@@ -236,7 +240,7 @@ pub mod io {
 
         impl<'de, T> Flavor<'de> for EIOReader<'de, T>
         where
-            T: embedded_io::blocking::Read + 'de,
+            T: crate::eio::Read + 'de,
         {
             type Remainder = (T, &'de mut [u8]);
             type Source = &'de [u8];

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -67,12 +67,12 @@ where
     Ok((t, deserializer.finalize()?))
 }
 
-/// Deserialize a message of type `T` from a [embedded_io::blocking::Read].
-#[cfg(feature = "embedded-io")]
+/// Deserialize a message of type `T` from a [`embedded_io`](crate::eio::embedded_io)::[`Read`](crate::eio::Read).
+#[cfg(any(feature = "embedded-io-04", feature = "embedded-io-06"))]
 pub fn from_eio<'a, T, R>(val: (R, &'a mut [u8])) -> Result<(T, (R, &'a mut [u8]))>
 where
     T: Deserialize<'a>,
-    R: embedded_io::blocking::Read + 'a,
+    R: crate::eio::Read + 'a,
 {
     let flavor = flavors::io::eio::EIOReader::new(val.0, val.1);
     let mut deserializer = Deserializer::from_flavor(flavor);

--- a/src/eio.rs
+++ b/src/eio.rs
@@ -1,0 +1,18 @@
+#[cfg(all(feature = "embedded-io-04", feature = "embedded-io-06"))]
+compile_error!("Only one version of `embedded-io` must be enabled through features");
+
+#[cfg(feature = "embedded-io-04")]
+mod version_impl {
+    pub use embedded_io_04 as embedded_io;
+    pub use embedded_io_04::blocking::{Read, Write};
+}
+
+#[cfg(feature = "embedded-io-06")]
+mod version_impl {
+    pub use embedded_io_06 as embedded_io;
+    pub use embedded_io_06::{Read, Write};
+}
+
+// All versions should export the appropriate items
+#[cfg(any(feature = "embedded-io-04", feature = "embedded-io-06"))]
+pub use version_impl::{embedded_io, Read, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 
 pub mod accumulator;
 mod de;
+
+mod eio;
+
 mod error;
 pub mod fixint;
 mod ser;
@@ -88,10 +91,10 @@ pub use ser::{serialize_with_flavor, serializer::Serializer, to_extend, to_slice
 #[cfg(feature = "heapless")]
 pub use ser::{to_vec, to_vec_cobs};
 
-#[cfg(feature = "embedded-io")]
+#[cfg(any(feature = "embedded-io-04", feature = "embedded-io-06"))]
 pub use ser::to_eio;
 
-#[cfg(feature = "embedded-io")]
+#[cfg(any(feature = "embedded-io-04", feature = "embedded-io-06"))]
 pub use de::from_eio;
 
 #[cfg(feature = "use-std")]

--- a/src/ser/flavors.rs
+++ b/src/ser/flavors.rs
@@ -250,23 +250,23 @@ where
     }
 }
 
-/// Support for the [embedded-io] traits
-#[cfg(feature = "embedded-io")]
+/// Support for the [`embedded-io`](crate::eio::embedded_io) traits
+#[cfg(any(feature = "embedded-io-04", feature = "embedded-io-06"))]
 pub mod eio {
 
     use super::Flavor;
     use crate::{Error, Result};
 
-    /// Wrapper over a [embedded_io::blocking::Write] that implements the flavor trait
+    /// Wrapper over a [`embedded_io Write`](crate::eio::Write) that implements the flavor trait
     pub struct WriteFlavor<T> {
         writer: T,
     }
 
     impl<T> WriteFlavor<T>
     where
-        T: embedded_io::blocking::Write,
+        T: crate::eio::Write,
     {
-        /// Create a new [Self] flavor from a given [std::io::Write]
+        /// Create a new [Self] flavor from a given [`embedded_io Write`](crate::eio::Write)
         pub fn new(writer: T) -> Self {
             Self { writer }
         }
@@ -274,7 +274,7 @@ pub mod eio {
 
     impl<T> Flavor for WriteFlavor<T>
     where
-        T: embedded_io::blocking::Write,
+        T: crate::eio::Write,
     {
         type Output = T;
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -274,7 +274,7 @@ where
     serialize_with_flavor::<T, _, _>(value, flavors::ExtendFlavor::new(writer))
 }
 
-/// Serialize a `T` to a [embedded_io::blocking::Write],
+/// Serialize a `T` to an [`embedded_io Write`](crate::eio::Write),
 /// ## Example
 ///
 /// ```rust
@@ -286,11 +286,11 @@ where
 /// to_eio("Hi!", ser).unwrap();
 /// assert_eq!(&buf[0..5], &[0x01, 0x03, b'H', b'i', b'!']);
 /// ```
-#[cfg(feature = "embedded-io")]
+#[cfg(any(feature = "embedded-io-04", feature = "embedded-io-06"))]
 pub fn to_eio<'b, T, W>(value: &'b T, writer: W) -> Result<W>
 where
     T: Serialize + ?Sized,
-    W: embedded_io::blocking::Write,
+    W: crate::eio::Write,
 {
     serialize_with_flavor::<T, _, _>(value, flavors::eio::WriteFlavor::new(writer))
 }

--- a/tests/loopback.rs
+++ b/tests/loopback.rs
@@ -210,7 +210,10 @@ fn std_io_loopback() {
     );
 }
 
-#[cfg(all(feature = "embedded-io", feature = "alloc"))]
+#[cfg(all(
+    any(feature = "embedded-io-04", feature = "embedded-io-06"),
+    feature = "alloc"
+))]
 #[test]
 fn std_eio_loopback() {
     use postcard::from_eio;


### PR DESCRIPTION
This adds a new `embedded-io-06`  feature which allows users to use the latest `embedded_io` v `0.6.*`.

Backwards compatibility is maintained with the previous `embedded-io` which is now setup to activate the `embedded-io-04` feature internally.