### PR TITLE
Add a performant way to (de-)serialize fixed-size byte arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,5 +92,21 @@ use-crc = ["crc", "paste"]
 # NOT subject to SemVer guarantees!
 experimental-derive = ["postcard-derive", "const_format"]
 
+[dev-dependencies.criterion]
+version = "0.5"
+
+[dev-dependencies.serde-big-array]
+version = "0.5.1"
+
+[dev-dependencies.serde_bytes]
+version = "0.11.12"
+
+[dev-dependencies.serde-byte-array]
+version = "0.1.2"
+
+[[bench]]
+name = "byte_array"
+harness = false
+
 [workspace]
 members = ["postcard-derive"]

--- a/benches/byte_array.rs
+++ b/benches/byte_array.rs
@@ -1,0 +1,105 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use postcard::FixedSizeByteArray;
+use serde::{Deserialize, Serialize};
+use serde_byte_array::ByteArray;
+use serde_bytes::{Bytes, ByteBuf};
+
+fn serialize<const N: usize, const B: usize>(c: &mut Criterion)
+where
+    [u8; N]: Serialize
+{
+    let own: &_ = &FixedSizeByteArray::from([0; N]);
+    let bytes: &_ = Bytes::new(&[0; N]);
+    let byte_array: &_ = &ByteArray::new([0; N]);
+    let big_array: &_ = &serde_big_array::Array([0; N]);
+    let fixed: &_ = &[0; N];
+    let variable: &[u8] = &[0; N];
+    let mut buf = [0; B];
+    let mut group = c.benchmark_group(format!("serialize{}", N));
+    group.bench_function("own", |b| b.iter(|| {
+        let _ = black_box(postcard::to_slice(black_box(own), &mut buf).unwrap());
+    }));
+    group.bench_function("bytes", |b| b.iter(|| {
+        let _ = black_box(postcard::to_slice(black_box(bytes), &mut buf).unwrap());
+    }));
+    group.bench_function("byte_array", |b| b.iter(|| {
+        let _ = black_box(postcard::to_slice(black_box(byte_array), &mut buf).unwrap());
+    }));
+    group.bench_function("big_array", |b| b.iter(|| {
+        let _ = black_box(postcard::to_slice(black_box(big_array), &mut buf).unwrap());
+    }));
+    group.bench_function("fixed_size", |b| b.iter(|| {
+        let _ = black_box(postcard::to_slice(black_box(fixed), &mut buf).unwrap());
+    }));
+    group.bench_function("variable_size", |b| b.iter(|| {
+        let _ = black_box(postcard::to_slice(black_box(variable), &mut buf).unwrap());
+    }));
+    group.finish();
+}
+
+fn deserialize<const N: usize, const SN: usize>(c: &mut Criterion)
+where
+    [u8; N]: Deserialize<'static>
+{
+    let data = &[0; N];
+    let mut data_prefixed = [0; SN];
+    data_prefixed[0] = N as u8;
+    let data_prefixed = &data_prefixed;
+
+    let mut group = c.benchmark_group(format!("deserialize{}", N));
+    group.bench_function("own", |b| b.iter(|| {
+        let _: FixedSizeByteArray<N> = black_box(postcard::from_bytes(black_box(data)).unwrap());
+    }));
+    group.bench_function("bytes", |b| b.iter(|| {
+        let _: ByteBuf = black_box(postcard::from_bytes(black_box(data_prefixed)).unwrap());
+    }));
+    group.bench_function("byte_array", |b| b.iter(|| {
+        let _: ByteArray<N> = black_box(postcard::from_bytes(black_box(data_prefixed)).unwrap());
+    }));
+    group.bench_function("big_array", |b| b.iter(|| {
+        let _: serde_big_array::Array<u8, N> = black_box(postcard::from_bytes(black_box(data)).unwrap());
+    }));
+    group.bench_function("fixed_size", |b| b.iter(|| {
+        let _: [u8; N] = black_box(postcard::from_bytes(black_box(data)).unwrap());
+    }));
+    group.bench_function("variable_size", |b| b.iter(|| {
+        let _: Vec<u8> = black_box(postcard::from_bytes(black_box(data_prefixed)).unwrap());
+    }));
+    group.finish();
+}
+
+fn serialize0(c: &mut Criterion) { serialize::<0, 64>(c) }
+fn serialize1(c: &mut Criterion) { serialize::<1, 64>(c) }
+fn serialize2(c: &mut Criterion) { serialize::<2, 64>(c) }
+fn serialize4(c: &mut Criterion) { serialize::<4, 64>(c) }
+fn serialize8(c: &mut Criterion) { serialize::<8, 64>(c) }
+fn serialize16(c: &mut Criterion) { serialize::<16, 64>(c) }
+fn serialize32(c: &mut Criterion) { serialize::<32, 64>(c) }
+
+fn deserialize0(c: &mut Criterion) { deserialize::<0, 1>(c) }
+fn deserialize1(c: &mut Criterion) { deserialize::<1, 2>(c) }
+fn deserialize2(c: &mut Criterion) { deserialize::<2, 3>(c) }
+fn deserialize4(c: &mut Criterion) { deserialize::<4, 5>(c) }
+fn deserialize8(c: &mut Criterion) { deserialize::<8, 9>(c) }
+fn deserialize16(c: &mut Criterion) { deserialize::<16, 17>(c) }
+fn deserialize32(c: &mut Criterion) { deserialize::<32, 33>(c) }
+
+criterion_group!(byte_array,
+    serialize0,
+    serialize1,
+    serialize2,
+    serialize4,
+    serialize8,
+    serialize16,
+    serialize32,
+
+    deserialize0,
+    deserialize1,
+    deserialize2,
+    deserialize4,
+    deserialize8,
+    deserialize16,
+    deserialize32,
+);
+
+criterion_main!(byte_array);

--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -1,0 +1,142 @@
+use serde::ser::SerializeStruct;
+use serde::Serialize;
+use serde::Serializer;
+
+use core::convert::TryInto;
+use core::fmt;
+use serde::Deserializer;
+use serde::Deserialize;
+use serde::de;
+
+/// Represents a fixed-size byte array for better performance with `postcard`.
+///
+/// This struct *only* works with `postcard` (de-)serialization.
+#[repr(transparent)]
+pub struct FixedSizeByteArray<const N: usize> {
+    inner: FixedSizeByteArrayInner<N>,
+}
+
+impl<const N: usize> From<[u8; N]> for FixedSizeByteArray<N> {
+    fn from(array: [u8; N]) -> FixedSizeByteArray<N> {
+        FixedSizeByteArray {
+            inner: FixedSizeByteArrayInner {
+                array,
+            },
+        }
+    }
+}
+
+impl<const N: usize> FixedSizeByteArray<N> {
+    /// Extract the actual array.
+    pub fn into_inner(self) -> [u8; N] {
+        self.inner.array
+    }
+}
+
+#[repr(transparent)]
+struct FixedSizeByteArrayInner<const N: usize> {
+    array: [u8; N],
+}
+
+pub static TOKEN: &str = "$postcard::private::FixedSizeByteArray";
+
+impl<const N: usize> Serialize for FixedSizeByteArray<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct(TOKEN, 1)?;
+        s.serialize_field(TOKEN, &self.inner)?;
+        s.end()
+    }
+}
+
+impl<const N: usize> Serialize for FixedSizeByteArrayInner<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.array)
+    }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for FixedSizeByteArray<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor<const N: usize>;
+
+        impl<'de, const N: usize> de::Visitor<'de> for Visitor<N> {
+            type Value = FixedSizeByteArray<N>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "byte array of length {}", N)
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let array: [u8; N] = match v.try_into() {
+                    Ok(a) => a,
+                    Err(_) => return Err(de::Error::invalid_length(v.len(), &self)),
+                };
+                Ok(FixedSizeByteArray::from(array))
+            }
+        }
+
+        deserializer.deserialize_tuple_struct(TOKEN, N, Visitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Error;
+    use super::FixedSizeByteArray;
+
+    #[test]
+    fn test_byte_array_serialize() {
+        let empty = FixedSizeByteArray::from([]);
+        let mut buf = [0; 32];
+        let serialized = crate::to_slice(&empty, &mut buf).unwrap();
+        assert_eq!(serialized, &[]);
+
+        let single = FixedSizeByteArray::from([0x12]);
+        let mut buf = [0; 32];
+        let serialized = crate::to_slice(&single, &mut buf).unwrap();
+        assert_eq!(serialized, &[0x12]);
+
+        let five_bytes = FixedSizeByteArray::from([0x12, 0x34, 0x56, 0x78, 0x90]);
+        let mut buf = [0; 32];
+        let serialized = crate::to_slice(&five_bytes, &mut buf).unwrap();
+        assert_eq!(serialized, &[0x12, 0x34, 0x56, 0x78, 0x90]);
+    }
+
+    #[test]
+    fn test_byte_array_deserialize() {
+        let deserialized: FixedSizeByteArray<0> = crate::from_bytes(&[]).unwrap();
+        assert_eq!(deserialized.into_inner(), []);
+
+        let deserialized: FixedSizeByteArray<0> = crate::from_bytes(&[0x12]).unwrap();
+        assert_eq!(deserialized.into_inner(), []);
+
+        let deserialized: FixedSizeByteArray<1> = crate::from_bytes(&[0x12]).unwrap();
+        assert_eq!(deserialized.into_inner(), [0x12]);
+
+        let deserialized: FixedSizeByteArray<5> = crate::from_bytes(&[0x12, 0x34, 0x56, 0x78, 0x90]).unwrap();
+        assert_eq!(deserialized.into_inner(), [0x12, 0x34, 0x56, 0x78, 0x90]);
+    }
+
+    #[test]
+    fn test_byte_array_deserialize_error() {
+        let result: Result<FixedSizeByteArray<1>, _> = crate::from_bytes(&[]);
+        assert_eq!(result.err().unwrap(), Error::DeserializeUnexpectedEnd);
+
+        let result: Result<FixedSizeByteArray<8>, _> = crate::from_bytes(&[0x12]);
+        assert_eq!(result.err().unwrap(), Error::DeserializeUnexpectedEnd);
+
+        let result: Result<FixedSizeByteArray<8>, _> = crate::from_bytes(&[0x12, 0x34, 0x56, 0x78]);
+        assert_eq!(result.err().unwrap(), Error::DeserializeUnexpectedEnd);
+    }
+}

--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -1,4 +1,4 @@
-use serde::ser::SerializeStruct;
+use serde::ser::SerializeTupleStruct;
 use serde::Serialize;
 use serde::Serializer;
 
@@ -45,8 +45,8 @@ impl<const N: usize> Serialize for FixedSizeByteArray<N> {
     where
         S: Serializer,
     {
-        let mut s = serializer.serialize_struct(TOKEN, 1)?;
-        s.serialize_field(TOKEN, &self.inner)?;
+        let mut s = serializer.serialize_tuple_struct(TOKEN, 1)?;
+        s.serialize_field(&self.inner)?;
         s.end()
     }
 }

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -473,14 +473,19 @@ impl<'de, 'a, F: Flavor<'de>> de::Deserializer<'de> for &'a mut Deserializer<'de
     #[inline]
     fn deserialize_tuple_struct<V>(
         self,
-        _name: &'static str,
+        name: &'static str,
         len: usize,
         visitor: V,
     ) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_tuple(len, visitor)
+        if name.as_ptr() == crate::byte_array::TOKEN.as_ptr() {
+            let bytes: &'de [u8] = self.flavor.try_take_n(len)?;
+            visitor.visit_borrowed_bytes(bytes)
+        } else {
+            self.deserialize_tuple(len, visitor)
+        }
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 pub mod accumulator;
+mod byte_array;
 mod de;
 
 mod eio;
@@ -81,6 +82,7 @@ pub mod experimental {
     }
 }
 
+pub use byte_array::FixedSizeByteArray;
 pub use de::deserializer::Deserializer;
 pub use de::flavors as de_flavors;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -80,7 +80,7 @@ where
     type SerializeTupleStruct = Self;
     type SerializeTupleVariant = Self;
     type SerializeMap = Self;
-    type SerializeStruct = Self;
+    type SerializeStruct = SerializeStruct<'a, F>;
     type SerializeStructVariant = Self;
 
     #[inline]
@@ -300,8 +300,12 @@ where
     }
 
     #[inline]
-    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
-        Ok(self)
+    fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(if name.as_ptr() == crate::byte_array::TOKEN.as_ptr() {
+            SerializeStruct::ByteArray { ser: self }
+        } else {
+            SerializeStruct::Struct { ser: self }
+        })
     }
 
     #[inline]
@@ -505,7 +509,200 @@ where
     }
 }
 
-impl<'a, F> ser::SerializeStruct for &'a mut Serializer<F>
+struct FixedSizeByteArrayEmitter<'a, F>(&'a mut Serializer<F>) where F: Flavor;
+
+impl<'a, F: Flavor> ser::Serializer for FixedSizeByteArrayEmitter<'a, F> {
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = ser::Impossible<(), Error>;
+    type SerializeTuple = ser::Impossible<(), Error>;
+    type SerializeTupleStruct = ser::Impossible<(), Error>;
+    type SerializeTupleVariant = ser::Impossible<(), Error>;
+    type SerializeMap = ser::Impossible<(), Error>;
+    type SerializeStruct = ser::Impossible<(), Error>;
+    type SerializeStructVariant = ser::Impossible<(), Error>;
+
+    fn serialize_bool(self, _v: bool) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_i128(self, _v: i128) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_u128(self, _v: u128) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_char(self, _v: char) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_str(self, _value: &str) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<()> {
+        let FixedSizeByteArrayEmitter(serializer) = self;
+        serializer.output.try_extend(value)
+    }
+
+    fn serialize_none(self) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_unit(self) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<()> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_newtype_struct<T>(self, _name: &'static str, _value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+
+    fn collect_str<T>(self, _value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + core::fmt::Display,
+    {
+        Err(ser::Error::custom("expected FixedSizeByteArray"))
+    }
+}
+
+
+pub enum SerializeStruct<'a, F>
+where
+    F: Flavor,
+{
+    Struct {
+        ser: &'a mut Serializer<F>,
+    },
+    ByteArray {
+        ser: &'a mut Serializer<F>,
+    },
+    ByteArrayDone,
+}
+
+impl<'a, F> ser::SerializeStruct for SerializeStruct<'a, F>
 where
     F: Flavor,
 {
@@ -513,11 +710,23 @@ where
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(&mut **self)
+        match self {
+            SerializeStruct::Struct { ser } => value.serialize(&mut **ser),
+            SerializeStruct::ByteArray { ser } => {
+                if key.as_ptr() == crate::byte_array::TOKEN.as_ptr() {
+                    value.serialize(FixedSizeByteArrayEmitter(&mut **ser))?;
+                    *self = SerializeStruct::ByteArrayDone;
+                    Ok(())
+                } else {
+                    unreachable!();
+                }
+            },
+            SerializeStruct::ByteArrayDone => unreachable!(),
+        }
     }
 
     #[inline]


### PR DESCRIPTION
First observed in https://github.com/est31/serde-big-array/issues/19, there's no performant way to serialize fixed-size byte arrays with serde/postcard.

Add a `FixedSizeByteArray` type that can be used to serialize fixed-size byte arrays faster than all other available methods. This type only works with postcard. A more general solution would need to be implemented in serde itself.

This works around https://github.com/serde-rs/serde/issues/2680.

```
serialize16/own                 [3.8846 ns 3.8909 ns 3.8988 ns]
serialize16/bytes               [9.9192 ns 9.9503 ns 9.9907 ns]
serialize16/byte_array          [4.1374 ns 4.1461 ns 4.1564 ns]
serialize16/big_array           [68.245 ns 68.344 ns 68.454 ns]
serialize16/fixed_size          [9.9966 ns 10.030 ns 10.076 ns]
serialize16/variable_size       [15.696 ns 15.795 ns 15.898 ns]

serialize32/own                 [4.1744 ns 4.1857 ns 4.2014 ns]
serialize32/bytes               [9.6590 ns 9.6825 ns 9.7151 ns]
serialize32/byte_array          [4.5584 ns 4.5663 ns 4.5747 ns]
serialize32/big_array           [135.38 ns 135.78 ns 136.34 ns]
serialize32/fixed_size          [13.989 ns 14.034 ns 14.091 ns]
serialize32/variable_size       [21.223 ns 21.270 ns 21.328 ns]

deserialize16/own               [5.9018 ns 5.9143 ns 5.9272 ns]
deserialize16/bytes             [21.198 ns 21.278 ns 21.376 ns]
deserialize16/byte_array        [6.8560 ns 6.8719 ns 6.8934 ns]
deserialize16/big_array         [19.027 ns 19.098 ns 19.187 ns]
deserialize16/fixed_size        [7.9197 ns 7.9471 ns 7.9817 ns]
deserialize16/variable_size     [36.804 ns 36.871 ns 36.946 ns]

deserialize32/own               [8.8860 ns 8.8989 ns 8.9139 ns]
deserialize32/bytes             [21.241 ns 21.271 ns 21.321 ns]
deserialize32/byte_array        [11.441 ns 11.459 ns 11.481 ns]
deserialize32/big_array         [31.553 ns 31.618 ns 31.697 ns]
deserialize32/fixed_size        [17.334 ns 17.360 ns 17.386 ns]
deserialize32/variable_size     [59.705 ns 59.815 ns 59.949 ns]
```

- `own` is the new `FixedSizeByteArray`, no length prefix.
- `bytes` is `serde_bytes::Bytes`, it has a length prefix.
- `byte_array` is `serde_byte_array::ByteArray`, it has a length prefix.
- `big_array` is `serde_big_array::Array`, no length prefix.
- `fixed_size` is `[u8; _]`, no length prefix.
- `variable_size` is `[u8]`, it has a length prefix.