### PR TITLE
Remove unnecessary lifetimes of CRC digest

### DIFF
--- a/src/ser/flavors.rs
+++ b/src/ser/flavors.rs
@@ -638,10 +638,10 @@ pub mod crc {
                     ///
                     /// When successful, this function returns the slice containing the
                     /// serialized and encoded message.
-                    pub fn [<to_slice_ $int>]<'a, 'b, T>(
-                        value: &'b T,
+                    pub fn [<to_slice_ $int>]<'a, T>(
+                        value: &T,
                         buf: &'a mut [u8],
-                        digest: Digest<'a, $int>,
+                        digest: Digest<'_, $int>,
                     ) -> Result<&'a mut [u8]>
                     where
                         T: Serialize + ?Sized,
@@ -653,9 +653,9 @@ pub mod crc {
                     /// data followed by a CRC. The CRC bytes are included in the output `Vec`.
                     #[cfg(feature = "heapless")]
                     #[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
-                    pub fn [<to_vec_ $int>]<'a, T, const B: usize>(
+                    pub fn [<to_vec_ $int>]<T, const B: usize>(
                         value: &T,
-                        digest: Digest<'a, $int>,
+                        digest: Digest<'_, $int>,
                     ) -> Result<heapless::Vec<u8, B>>
                     where
                         T: Serialize + ?Sized,
@@ -669,7 +669,7 @@ pub mod crc {
                     /// data followed by a CRC. The CRC bytes are included in the output `Vec`.
                     #[cfg(feature = "alloc")]
                     #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-                    pub fn [<to_allocvec_ $int>]<'a, T>(value: &T, digest: Digest<'a, $int>) -> Result<alloc::vec::Vec<u8>>
+                    pub fn [<to_allocvec_ $int>]<T>(value: &T, digest: Digest<'_, $int>) -> Result<alloc::vec::Vec<u8>>
                     where
                         T: Serialize + ?Sized,
                     {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -339,10 +339,10 @@ where
 #[cfg(feature = "use-crc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "use-crc")))]
 #[inline]
-pub fn to_slice_crc32<'a, 'b, T>(
-    value: &'b T,
+pub fn to_slice_crc32<'a, T>(
+    value: &T,
     buf: &'a mut [u8],
-    digest: crc::Digest<'a, u32>,
+    digest: crc::Digest<'_, u32>,
 ) -> Result<&'a mut [u8]>
 where
     T: Serialize + ?Sized,
@@ -375,9 +375,9 @@ where
 #[cfg(all(feature = "use-crc", feature = "heapless"))]
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "use-crc", feature = "heapless"))))]
 #[inline]
-pub fn to_vec_crc32<'a, T, const B: usize>(
+pub fn to_vec_crc32<T, const B: usize>(
     value: &T,
-    digest: crc::Digest<'a, u32>,
+    digest: crc::Digest<'_, u32>,
 ) -> Result<heapless::Vec<u8, B>>
 where
     T: Serialize + ?Sized,
@@ -409,7 +409,7 @@ where
 #[cfg(all(feature = "use-crc", feature = "use-std"))]
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "use-crc", feature = "use-std"))))]
 #[inline]
-pub fn to_stdvec_crc32<'a, T>(value: &T, digest: crc::Digest<'a, u32>) -> Result<std::vec::Vec<u8>>
+pub fn to_stdvec_crc32<T>(value: &T, digest: crc::Digest<'_, u32>) -> Result<std::vec::Vec<u8>>
 where
     T: Serialize + ?Sized,
 {
@@ -440,9 +440,9 @@ where
 #[cfg(all(feature = "use-crc", feature = "alloc"))]
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "use-crc", feature = "alloc"))))]
 #[inline]
-pub fn to_allocvec_crc32<'a, T>(
+pub fn to_allocvec_crc32<T>(
     value: &T,
-    digest: crc::Digest<'a, u32>,
+    digest: crc::Digest<'_, u32>,
 ) -> Result<alloc::vec::Vec<u8>>
 where
     T: Serialize + ?Sized,


### PR DESCRIPTION
The CRC digest lifetime is set to the same as the provided buffer lifetime which means that the CRC has to live as long as the buffer which I don't think is necessary as the `finalize()` method is called on the digest. This strictness of the lifetime meant that I couldn't create a `Crc` in the local scope i.e. a method and then just return the bytes (see the new unit test for an example of what I mean).

Clippy suggests this change and to remove a few other lifetimes too so I think this should be a low risk change :slightly_smiling_face:

Thanks for the great crate!