### PR TITLE
Depend directly on serde_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,11 @@ features = ["serde"]
 optional = true
 
 [dependencies.serde]
-version = "1.0.100"
+version = "1.0.186"
 default-features = false
-features = ["derive"]
+
+[dependencies.serde_derive]
+version = "1"
 
 [dependencies.cobs]
 version = "0.2.3"
@@ -69,6 +71,9 @@ optional = true
 [dependencies.paste]
 version = "1.0.12"
 optional = true
+
+[dev-dependencies.serde_derive]
+version = "1"
 
 [features]
 default = ["heapless-cas"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ default-features = false
 
 [dependencies.serde_derive]
 version = "1"
+optional = true
 
 [dependencies.cobs]
 version = "0.2.3"
@@ -95,7 +96,7 @@ use-crc = ["crc", "paste"]
 # Experimental features!
 #
 # NOT subject to SemVer guarantees!
-experimental-derive = ["postcard-derive", "const_format"]
+experimental-derive = ["postcard-derive", "const_format", "dep:serde_derive"]
 
 [workspace]
 members = ["postcard-derive"]

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -1,6 +1,6 @@
 //! An accumulator used to collect chunked COBS data and deserialize it.
 
-use serde::Deserialize;
+use serde::de::Deserialize;
 
 /// An accumulator used to collect chunked COBS data and deserialize it.
 ///
@@ -13,11 +13,12 @@ use serde::Deserialize;
 ///
 /// ```rust
 /// use postcard::accumulator::{CobsAccumulator, FeedResult};
-/// use serde::Deserialize;
+/// use serde::de::Deserialize;
+/// use serde_derive::{Deserialize, Serialize};
 /// use std::io::Read;
 ///
 /// # let mut input_buf = [0u8; 256];
-/// # #[derive(serde::Serialize, Deserialize, Debug, PartialEq, Eq)]
+/// # #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 /// # struct MyData {
 /// #     a: u32,
 /// #     b: bool,
@@ -179,10 +180,11 @@ impl<const N: usize> CobsAccumulator<N> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use serde_derive::{Deserialize, Serialize};
 
     #[test]
     fn loop_test() {
-        #[derive(serde::Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
         struct Demo {
             a: u32,
             b: u8,
@@ -203,7 +205,7 @@ mod test {
 
     #[test]
     fn double_loop_test() {
-        #[derive(serde::Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
         struct Demo {
             a: u32,
             b: u8,
@@ -247,7 +249,7 @@ mod test {
 
     #[test]
     fn loop_test_ref() {
-        #[derive(serde::Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
         struct Demo<'a> {
             a: u32,
             b: u8,
@@ -280,7 +282,7 @@ mod test {
 
     #[test]
     fn double_loop_test_ref() {
-        #[derive(serde::Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
         struct Demo<'a> {
             a: u32,
             b: u8,
@@ -342,7 +344,7 @@ mod test {
         // Test bug present in revision abcb407:
         // extend_unchecked may be passed slice with size 1 greater than accumulator buffer causing panic
 
-        #[derive(serde::Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
         struct Demo {
             data: [u8; 10],
         }

--- a/src/de/flavors.rs
+++ b/src/de/flavors.rs
@@ -54,7 +54,8 @@
 //!     de_flavors::Slice,
 //!     Deserializer,
 //! };
-//! use serde::Deserialize;
+//! use serde::de::Deserialize;
+//! use serde_derive::Deserialize;
 //!
 //! #[derive(Deserialize, Debug, PartialEq)]
 //! struct Tup(u8, u8, u8);

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -134,7 +134,9 @@ mod test_heapless {
     use core::fmt::Write;
     use core::ops::Deref;
     use heapless::{FnvIndexMap, String, Vec};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::de::{Deserialize, Deserializer};
+    use serde::ser::{Serialize, Serializer};
+    use serde_derive::{Deserialize, Serialize};
 
     #[test]
     fn de_u8() {

--- a/src/fixint.rs
+++ b/src/fixint.rs
@@ -21,7 +21,8 @@ use serde::{Deserialize, Serialize, Serializer};
 /// size array, in **Little Endian** order on the wire.
 ///
 /// ```rust
-/// # use serde::Serialize;
+/// # use serde::ser::Serialize;
+/// # use serde_derive::Serialize;
 /// #[derive(Serialize)]
 /// pub struct DefinitelyLittleEndian {
 ///     #[serde(with = "postcard::fixint::le")]
@@ -59,7 +60,7 @@ pub mod le {
 /// size array, in **Big Endian** order on the wire.
 ///
 /// ```rust
-/// # use serde::Serialize;
+/// # use serde_derive::Serialize;
 /// #[derive(Serialize)]
 /// pub struct DefinitelyBigEndian {
 ///     #[serde(with = "postcard::fixint::be")]
@@ -151,7 +152,7 @@ impl_fixint![i16, i32, i64, i128, u16, u32, u64, u128];
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
+    use serde_derive::{Deserialize, Serialize};
 
     #[test]
     fn test_little_endian() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod varint;
 
 // Still experimental! Don't make pub pub.
 pub(crate) mod max_size;
+#[cfg(feature = "experimental-derive")]
 pub(crate) mod schema;
 
 /// # Experimental Postcard Features

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use serde::Serialize;
+use serde_derive::Serialize;
 
 /// A schema type representing a variably encoded integer
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -506,7 +506,7 @@ mod test {
     use core::fmt::Write;
     use core::ops::{Deref, DerefMut};
     use heapless::{FnvIndexMap, String};
-    use serde::Deserialize;
+    use serde_derive::{Deserialize, Serialize};
 
     #[test]
     fn ser_u8() {

--- a/tests/accumulator.rs
+++ b/tests/accumulator.rs
@@ -1,5 +1,5 @@
 use postcard::accumulator::{CobsAccumulator, FeedResult};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::io::Read;
 
 // Read a "huge" serialized struct in 32 byte chunks into a 256 byte buffer and deserialize it.

--- a/tests/loopback.rs
+++ b/tests/loopback.rs
@@ -10,7 +10,8 @@ use postcard::to_vec;
 
 use postcard::from_bytes;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::ser::Serialize;
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 struct BasicU8S {

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -4,7 +4,7 @@
 mod tests {
     use postcard::experimental::max_size::MaxSize;
     use postcard::to_slice;
-    use serde::Serialize;
+    use serde_derive::Serialize;
 
     #[test]
     fn test_struct_max_size() {


### PR DESCRIPTION
Since [serde v1.0.186](https://github.com/serde-rs/serde/releases/tag/v1.0.186), this is possible without risking errors from Cargo picking incompatible versions of `serde` and `serde_derive`. The benefit of *not* enabling serde's "derive" feature is that (non-incremental) builds can become a bit faster, as serde itself (and some things depending on it) can be compiled in parallel to proc-macro2, syn, and `serde_derive`. See https://github.com/serde-rs/serde/issues/2584 for more discussion and background. In a project of mine where all transitive dependencies except postcard have already made the switch, this patch makes a clean build 3-4 seconds faster (out of a minute in total) on my machine.

The downside of this change, besides the additional `use` lines, is that it's easy to accidentally write code that breaks when used in a project where something else enables serde's "derive" feature. Importing the traits from `serde::{Deserialize, Serialize}` works until it doesn't, one has to remember to always import the traits from `serde::ser` and `serde::de` (see https://github.com/serde-rs/serde/issues/1441). I think I did it correctly in this PR, but there's no good way to test it other than occasionally editing Cargo.toml to re-enable serde's "derive" feature. I'm honestly not sure if I'd want to deal with that as a library maintainer, no hard feelings if you don't want to either.

The second commit goes one step further and makes postcard's `serde_derive` dependency completely optional except as a dev-dependency, since it only seems to be needed for tests and for postcard-derive-related code in schema.rs. This is less impactful since virtually every crate depending on postcard also needs `serde_derive` anyway, but it shouldn't hurt either and doesn't make things any more complicated than the first commit.

This is a breaking change: projects using postcard are likely to depend on serde re-exporting the derive macros, and for some of them, postcard will be the only thing enabling serde's "derive" feature. But since a 2.0 release is likely coming anyway, I wanted to pitch this change.