### PR TITLE
Fix #89: `#[derive(Schema)]` for `StructVariant`s

### DIFF
--- a/postcard-derive/src/schema.rs
+++ b/postcard-derive/src/schema.rs
@@ -89,7 +89,7 @@ fn generate_variants(fields: &Fields) -> TokenStream {
             let fields = fields.named.iter().map(|f| {
                 let ty = &f.ty;
                 let name = f.ident.as_ref().unwrap().to_string();
-                quote_spanned!(f.span() => ::postcard::experimental::schema::NamedValue { name: #name, ty: <#ty as ::postcard::experimental::schema::Schema>::SCHEMA })
+                quote_spanned!(f.span() => &::postcard::experimental::schema::NamedValue { name: #name, ty: <#ty as ::postcard::experimental::schema::Schema>::SCHEMA })
             });
             quote! { &::postcard::experimental::schema::SdmTy::StructVariant(&[
                 #( #fields ),*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ mod varint;
 pub(crate) mod max_size;
 
 /// The schema types and macros.
+#[cfg(not(feature = "experimental-derive"))]
+mod schema;
+
+#[cfg(feature = "experimental-derive")]
 pub mod schema;
 
 /// # Experimental Postcard Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@ mod varint;
 
 // Still experimental! Don't make pub pub.
 pub(crate) mod max_size;
-pub(crate) mod schema;
+
+/// The schema types and macros.
+pub mod schema;
 
 /// # Experimental Postcard Features
 ///

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use serde::Serialize;
 
 /// A schema type representing a variably encoded integer

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -266,7 +266,7 @@ where
 /// let vec = to_extend("Hi!", ser).unwrap();
 /// assert_eq!(&vec[0..5], &[0x01, 0x03, b'H', b'i', b'!']);
 /// ```
-pub fn to_extend<'a, T, W>(value: &'a T, writer: W) -> Result<W>
+pub fn to_extend<T, W>(value: &T, writer: W) -> Result<W>
 where
     T: Serialize + ?Sized,
     W: core::iter::Extend<u8>,

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -374,7 +374,7 @@ where
             fn write_str(&mut self, s: &str) -> core::result::Result<(), core::fmt::Error> {
                 self.output
                     .try_extend(s.as_bytes())
-                    .map_err(|_| core::fmt::Error::default())
+                    .map_err(|_| core::fmt::Error)
             }
         }
 

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,6 +1,7 @@
-#![cfg(feature = "derive")]
+#![cfg(feature = "experimental-derive")]
 
 use postcard::schema::{NamedType, NamedValue, NamedVariant, Schema, SdmTy, Varint};
+use postcard_derive::Schema;
 
 const U8_SCHEMA: NamedType = NamedType {
     name: "u8",

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "experimental-derive")]
 
 use postcard::experimental::schema::{NamedType, NamedValue, NamedVariant, Schema, SdmTy, Varint};
-use postcard_derive::Schema;
 
 const U8_SCHEMA: NamedType = NamedType {
     name: "u8",
@@ -32,20 +31,18 @@ enum Inner {
     Beta,
     Gamma,
     Delta(i32, i16),
-    Epsilon {
-        zeta: f32,
-        eta: bool,
-    }
+    Epsilon { zeta: f32, eta: bool },
 }
 
 #[allow(unused)]
 #[derive(Schema)]
-struct Outer {
+struct Outer<'a> {
     a: u32,
     b: u64,
     c: u8,
     d: Inner,
-    e: [u8; 3],
+    e: [u8; 10],
+    f: &'a [u8],
 }
 
 #[allow(unused)]
@@ -81,12 +78,17 @@ fn test_enum_serialize() {
                     ty: &SdmTy::StructVariant(&[
                         &NamedValue {
                             name: "zeta",
-                            ty: &NamedType { name: "f32", ty: &SdmTy::F32 },
-                        }
-                        ,
+                            ty: &NamedType {
+                                name: "f32",
+                                ty: &SdmTy::F32
+                            },
+                        },
                         &NamedValue {
                             name: "eta",
-                            ty: &NamedType { name: "bool", ty: &SdmTy::Bool },
+                            ty: &NamedType {
+                                name: "bool",
+                                ty: &SdmTy::Bool
+                            },
                         }
                     ]),
                 }
@@ -98,6 +100,8 @@ fn test_enum_serialize() {
 
 #[test]
 fn test_struct_serialize() {
+    const TEN_BYTES_SCHEMA: &'static [&'static NamedType] = &[&U8_SCHEMA; 10];
+
     assert_eq!(
         Outer::SCHEMA,
         &NamedType {
@@ -123,48 +127,17 @@ fn test_struct_serialize() {
                     name: "e",
                     ty: &NamedType {
                         name: "[T; N]",
-                        ty: &SdmTy::Tuple(&[
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                            &NamedType {
-                                name: "u8",
-                                ty: &SdmTy::U8
-                            },
-                        ])
+                        ty: &SdmTy::Tuple(TEN_BYTES_SCHEMA),
+                    }
+                },
+                &NamedValue {
+                    name: "f",
+                    ty: &NamedType {
+                        name: "&[T]",
+                        ty: &SdmTy::Seq(&NamedType {
+                            name: "u8",
+                            ty: &SdmTy::U8
+                        })
                     }
                 },
             ]),

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -75,6 +75,7 @@ fn test_enum_serialize() {
 #[test]
 fn test_struct_serialize() {
     assert_eq!(
+        Outer::SCHEMA,
         &NamedType {
             name: "Outer",
             ty: &SdmTy::Struct(&[
@@ -98,11 +99,51 @@ fn test_struct_serialize() {
                     name: "e",
                     ty: &NamedType {
                         name: "[T; N]",
-                        ty: &SdmTy::Seq(&U8_SCHEMA),
+                        ty: &SdmTy::Tuple(&[
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                            &NamedType {
+                                name: "u8",
+                                ty: &SdmTy::U8
+                            },
+                        ])
                     }
-                }
+                },
             ]),
-        },
-        Outer::SCHEMA
+        }
     );
 }

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -32,6 +32,10 @@ enum Inner {
     Beta,
     Gamma,
     Delta(i32, i16),
+    Epsilon {
+        zeta: f32,
+        eta: bool,
+    }
 }
 
 #[allow(unused)]
@@ -66,6 +70,20 @@ fn test_enum_serialize() {
                     name: "Delta",
                     ty: &SdmTy::TupleVariant(&[&I32_SCHEMA, &I16_SCHEMA,])
                 },
+                &NamedVariant {
+                    name: "Epsilon",
+                    ty: &SdmTy::StructVariant(&[
+                        &NamedValue {
+                            name: "zeta",
+                            ty: &NamedType { name: "f32", ty: &SdmTy::F32 },
+                        }
+                        ,
+                        &NamedValue {
+                            name: "eta",
+                            ty: &NamedType { name: "bool", ty: &SdmTy::Bool },
+                        }
+                    ]),
+                }
             ]),
         },
         Inner::SCHEMA


### PR DESCRIPTION
Here comes a 4-commit sandwich.

The actual issue I believe is fixed with this. However, there are 2 open questions regarding the schema tests (see commit message bodies):

* Where should the schema tests be located? As of now, they force the schema module to be `pub`lic because they are integration tests. A doc comment above `mod schema;` explicitly says not to make experimental features `pub` :laughing:
* The test for struct serialization does not pass. It seems it wants the array member to be schematized as a `Seq`, but the array member is schematized as a 10-element `Tuple`.

Let me know what you think :) I love using this crate.