### PR TITLE
Define MaxSize for Arc and Rc

### DIFF
--- a/src/max_size.rs
+++ b/src/max_size.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::{rc::Rc, sync::Arc};
+
 use crate::varint::varint_max;
 use core::{
     marker::PhantomData,
@@ -192,6 +198,18 @@ impl<A: MaxSize, B: MaxSize, C: MaxSize, D: MaxSize, E: MaxSize, F: MaxSize> Max
         + F::POSTCARD_MAX_SIZE;
 }
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+impl<T: MaxSize> MaxSize for Arc<T> {
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+impl<T: MaxSize> MaxSize for Rc<T> {
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
+}
+
 #[cfg(feature = "heapless")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
 impl<T: MaxSize, const N: usize> MaxSize for heapless::Vec<T, N> {
@@ -229,5 +247,29 @@ const fn max(lhs: usize, rhs: usize) -> usize {
         lhs
     } else {
         rhs
+    }
+}
+
+#[cfg(any(feature = "alloc", feature = "use-std"))]
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use super::*;
+    use alloc::rc::Rc;
+    use alloc::sync::Arc;
+
+    #[test]
+    fn arc_max_size() {
+        assert_eq!(Arc::<u8>::POSTCARD_MAX_SIZE, 1);
+        assert_eq!(Arc::<u32>::POSTCARD_MAX_SIZE, 5);
+        assert_eq!(Arc::<(u128, [u8; 8])>::POSTCARD_MAX_SIZE, 27);
+    }
+
+    #[test]
+    fn rc_max_size() {
+        assert_eq!(Rc::<u8>::POSTCARD_MAX_SIZE, 1);
+        assert_eq!(Rc::<u32>::POSTCARD_MAX_SIZE, 5);
+        assert_eq!(Rc::<(u128, [u8; 8])>::POSTCARD_MAX_SIZE, 27);
     }
 }


### PR DESCRIPTION
Serde supports auto-deriving Serialize and Deserialize for Arc and Rc types with the caveat being that the underlying type is serialized/deserialized. I am using this feature along with Postcard, and need this patch (or something equivalent to it) in order to calculate the max serialized size of my types.

More details on Serde's Arc and Rc support here: https://serde.rs/feature-flags.html#rc