### PR TITLE
Fix compilation with alloc and experimental-derive

### DIFF
--- a/src/max_size.rs
+++ b/src/max_size.rs
@@ -2,7 +2,7 @@
 extern crate alloc;
 
 #[cfg(feature = "alloc")]
-use alloc::{rc::Rc, sync::Arc};
+use alloc::{boxed::Box, rc::Rc, sync::Arc};
 
 use crate::varint::varint_max;
 use core::{


### PR DESCRIPTION
```sh
RUSTFLAGS='--check-cfg=cfg(doc_cfg)' cargo check --features=alloc,experimental-derive
```

Note that with a continuous integration, this would probably not happen, see #144.