### PR TITLE
Use well-known docsrs cfg for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ documentation = "https://docs.rs/postcard/"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 

--- a/src/de/flavors.rs
+++ b/src/de/flavors.rs
@@ -387,7 +387,7 @@ pub mod io {
 ///
 /// More on CRCs: <https://en.wikipedia.org/wiki/Cyclic_redundancy_check>.
 #[cfg(feature = "use-crc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "use-crc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "use-crc")))]
 pub mod crc {
     use core::convert::TryInto;
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -98,7 +98,7 @@ where
 ///
 /// See the `de_flavors::crc` module for the complete set of functions.
 #[cfg(feature = "use-crc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "use-crc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "use-crc")))]
 #[inline]
 pub fn from_bytes_crc32<'a, T>(s: &'a [u8], digest: crc::Digest<'a, u32>) -> Result<T>
 where
@@ -112,7 +112,7 @@ where
 ///
 /// See the `de_flavors::crc` module for the complete set of functions.
 #[cfg(feature = "use-crc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "use-crc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "use-crc")))]
 #[inline]
 pub fn take_from_bytes_crc32<'a, T>(
     s: &'a [u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(any(test, feature = "use-std")), no_std)]
 #![warn(missing_docs)]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod accumulator;
 mod de;
@@ -66,7 +66,7 @@ pub mod schema;
 pub mod experimental {
     /// Compile time max-serialization size calculation
     #[cfg(feature = "experimental-derive")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "experimental-derive")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental-derive")))]
     pub mod max_size {
         // NOTE: This is the trait...
         pub use crate::max_size::MaxSize;
@@ -78,7 +78,7 @@ pub mod experimental {
 
     /// Compile time Schema generation
     #[cfg(feature = "experimental-derive")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "experimental-derive")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental-derive")))]
     pub mod schema {
         // NOTE: This is the trait...
         pub use crate::schema::{NamedType, NamedValue, NamedVariant, Schema, SdmTy, Varint};

--- a/src/max_size.rs
+++ b/src/max_size.rs
@@ -199,31 +199,31 @@ impl<A: MaxSize, B: MaxSize, C: MaxSize, D: MaxSize, E: MaxSize, F: MaxSize> Max
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T: MaxSize> MaxSize for Box<T> {
     const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T: MaxSize> MaxSize for Arc<T> {
     const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T: MaxSize> MaxSize for Rc<T> {
     const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
 }
 
 #[cfg(feature = "heapless")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 impl<T: MaxSize, const N: usize> MaxSize for heapless::Vec<T, N> {
     const POSTCARD_MAX_SIZE: usize = <[T; N]>::POSTCARD_MAX_SIZE + varint_size(N);
 }
 
 #[cfg(feature = "heapless")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 impl<const N: usize> MaxSize for heapless::String<N> {
     const POSTCARD_MAX_SIZE: usize = <[u8; N]>::POSTCARD_MAX_SIZE + varint_size(N);
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -226,7 +226,7 @@ impl<T: Schema, const N: usize> Schema for [T; N] {
 }
 
 #[cfg(feature = "heapless")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 impl<T: Schema, const N: usize> Schema for heapless::Vec<T, N> {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "heapless::Vec<T, N>",
@@ -234,7 +234,7 @@ impl<T: Schema, const N: usize> Schema for heapless::Vec<T, N> {
     };
 }
 #[cfg(feature = "heapless")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 impl<const N: usize> Schema for heapless::String<N> {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "heapless::String<N>",
@@ -243,7 +243,7 @@ impl<const N: usize> Schema for heapless::String<N> {
 }
 
 #[cfg(feature = "use-std")]
-#[cfg_attr(doc_cfg, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: Schema> Schema for std::vec::Vec<T> {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "Vec<T>",
@@ -252,7 +252,7 @@ impl<T: Schema> Schema for std::vec::Vec<T> {
 }
 
 #[cfg(feature = "use-std")]
-#[cfg_attr(doc_cfg, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl Schema for std::string::String {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "String",

--- a/src/ser/flavors.rs
+++ b/src/ser/flavors.rs
@@ -572,7 +572,7 @@ where
 ///
 /// More on CRCs: <https://en.wikipedia.org/wiki/Cyclic_redundancy_check>.
 #[cfg(feature = "use-crc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "use-crc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "use-crc")))]
 pub mod crc {
     use crc::Digest;
     use crc::Width;
@@ -652,7 +652,7 @@ pub mod crc {
                     /// Serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
                     /// data followed by a CRC. The CRC bytes are included in the output `Vec`.
                     #[cfg(feature = "heapless")]
-                    #[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
+                    #[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
                     pub fn [<to_vec_ $int>]<T, const B: usize>(
                         value: &T,
                         digest: Digest<'_, $int>,
@@ -668,7 +668,7 @@ pub mod crc {
                     /// Serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
                     /// data followed by a CRC. The CRC bytes are included in the output `Vec`.
                     #[cfg(feature = "alloc")]
-                    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+                    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
                     pub fn [<to_allocvec_ $int>]<T>(value: &T, digest: Digest<'_, $int>) -> Result<alloc::vec::Vec<u8>>
                     where
                         T: Serialize + ?Sized,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -116,7 +116,7 @@ where
 /// assert_eq!(ser.deref(), &[0x02, 0x01, 0x03, 0x20, 0x30, 0x00]);
 /// ```
 #[cfg(feature = "heapless")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 pub fn to_vec_cobs<T, const B: usize>(value: &T) -> Result<Vec<u8, B>>
 where
     T: Serialize + ?Sized,
@@ -150,7 +150,7 @@ where
 /// assert_eq!(ser.deref(), &[0x01, 0x00, 0x20, 0x30]);
 /// ```
 #[cfg(feature = "heapless")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "heapless")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 pub fn to_vec<T, const B: usize>(value: &T) -> Result<Vec<u8, B>>
 where
     T: Serialize + ?Sized,
@@ -172,7 +172,7 @@ where
 /// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
 /// ```
 #[cfg(feature = "use-std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "use-std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "use-std")))]
 #[inline]
 pub fn to_stdvec<T>(value: &T) -> Result<std::vec::Vec<u8>>
 where
@@ -197,7 +197,7 @@ where
 /// assert_eq!(ser.as_slice(), &[0x05, 0x03, b'H', b'i', b'!', 0x00]);
 /// ```
 #[cfg(feature = "use-std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "use-std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "use-std")))]
 #[inline]
 pub fn to_stdvec_cobs<T>(value: &T) -> Result<std::vec::Vec<u8>>
 where
@@ -220,7 +220,7 @@ where
 /// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
 /// ```
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn to_allocvec<T>(value: &T) -> Result<alloc::vec::Vec<u8>>
 where
     T: Serialize + ?Sized,
@@ -244,7 +244,7 @@ where
 /// assert_eq!(ser.as_slice(), &[0x05, 0x03, b'H', b'i', b'!', 0x00]);
 /// ```
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn to_allocvec_cobs<T>(value: &T) -> Result<alloc::vec::Vec<u8>>
 where
     T: Serialize + ?Sized,
@@ -337,7 +337,7 @@ where
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
 #[cfg(feature = "use-crc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "use-crc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "use-crc")))]
 #[inline]
 pub fn to_slice_crc32<'a, T>(
     value: &T,
@@ -373,7 +373,7 @@ where
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
 #[cfg(all(feature = "use-crc", feature = "heapless"))]
-#[cfg_attr(doc_cfg, doc(cfg(all(feature = "use-crc", feature = "heapless"))))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "use-crc", feature = "heapless"))))]
 #[inline]
 pub fn to_vec_crc32<T, const B: usize>(
     value: &T,
@@ -407,7 +407,7 @@ where
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
 #[cfg(all(feature = "use-crc", feature = "use-std"))]
-#[cfg_attr(doc_cfg, doc(cfg(all(feature = "use-crc", feature = "use-std"))))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "use-crc", feature = "use-std"))))]
 #[inline]
 pub fn to_stdvec_crc32<T>(value: &T, digest: crc::Digest<'_, u32>) -> Result<std::vec::Vec<u8>>
 where
@@ -438,7 +438,7 @@ where
 ///
 /// See the `ser_flavors::crc` module for the complete set of functions.
 #[cfg(all(feature = "use-crc", feature = "alloc"))]
-#[cfg_attr(doc_cfg, doc(cfg(all(feature = "use-crc", feature = "alloc"))))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "use-crc", feature = "alloc"))))]
 #[inline]
 pub fn to_allocvec_crc32<T>(
     value: &T,


### PR DESCRIPTION
See https://github.com/rust-lang/cargo/pull/13383 for the PR adding support.

Without this change, there are many warnings about https://blog.rust-lang.org/2024/05/06/check-cfg.html when compiling.