### PR TITLE
Remove unnecessary lifetime from CRC digest in deserializer

### DIFF
--- a/source/postcard/src/de/mod.rs
+++ b/source/postcard/src/de/mod.rs
@@ -100,7 +100,7 @@ where
 #[cfg(feature = "use-crc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "use-crc")))]
 #[inline]
-pub fn from_bytes_crc32<'a, T>(s: &'a [u8], digest: crc::Digest<'a, u32>) -> Result<T>
+pub fn from_bytes_crc32<'a, T>(s: &'a [u8], digest: crc::Digest<'_, u32>) -> Result<T>
 where
     T: Deserialize<'a>,
 {
@@ -116,7 +116,7 @@ where
 #[inline]
 pub fn take_from_bytes_crc32<'a, T>(
     s: &'a [u8],
-    digest: crc::Digest<'a, u32>,
+    digest: crc::Digest<'_, u32>,
 ) -> Result<(T, &'a [u8])>
 where
     T: Deserialize<'a>,


### PR DESCRIPTION
This PR is the deserialize complement to https://github.com/jamesmunns/postcard/pull/129

This is required to allow wrappers such as

```rust
fn deserialize(buf: &[u8]) -> Result<Data<'_>, Error> {
    let crc = Crc::<u32>::new(&CRC_32_ISCSI);
    let digest = crc.digest();
    postcard::from_bytes_crc32(buf, digest).map_err(|_| Error::Deserialize)
}
```

without getting
```
   |
54 |         let digest = crc.digest();
   |                      --- `crc` is borrowed here
55 |         postcard::from_bytes_crc32(buf, digest).map_err(|_| Error::Deserialize)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returns a value referencing data owned by the current function
```
