### PR TITLE
Optionally implement `Schema` for `uuid::Uuid`

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -66,6 +66,12 @@ optional = true
 version = "1.0.12"
 optional = true
 
+[dependencies.uuid]
+version = "1.10.0"
+default-features = false
+features = ["serde"]
+optional = true
+
 [features]
 default = ["heapless-cas"]
 

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -241,6 +241,14 @@ impl<const N: usize> Schema for heapless::String<N> {
         ty: &SdmTy::String,
     };
 }
+#[cfg(feature = "uuid")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid")))]
+impl Schema for uuid::Uuid {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "uuid::Uuid",
+        ty: &SdmTy::ByteArray,
+    };
+}
 
 #[cfg(feature = "use-std")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]


### PR DESCRIPTION
It's a very commonly used type so it makes sense to provide optional support for it out of the box.