### PR TITLE
revert 'Update heapless (#115)'

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 
 [dependencies.heapless]
-version = "0.8.0"
+version = "0.7.0"
 default-features = false
 features = ["serde"]
 optional = true
@@ -78,7 +78,7 @@ embedded-io-04 = ["dep:embedded-io-04"]
 embedded-io-06 = ["dep:embedded-io-06"]
 
 use-std = ["serde/std", "alloc"]
-heapless-cas = ["heapless", "heapless/portable-atomic"]
+heapless-cas = ["heapless", "heapless/cas"]
 alloc = ["serde/alloc", "embedded-io-04?/alloc", "embedded-io-06?/alloc"]
 use-defmt = ["defmt"]
 use-crc = ["crc", "paste"]


### PR DESCRIPTION
See https://github.com/jamesmunns/postcard/issues/158

Enables cutting a release with #123

Appears to be semver-clean, running `cargo semver-checks --default-features` and `--only-explicit-features`