### PR TITLE
Check that target supports atomic pointer operations before defining max size for Arc

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -9,6 +9,7 @@ ensure_target() {
 }
 
 ensure_target thumbv7em-none-eabi
+ensure_target riscv32i-unknown-none-elf
 
 has_toolchain() {
   rustup toolchain list | grep -q "$1"
@@ -32,6 +33,10 @@ cargo_test --features=alloc,experimental-derive,use-std,use-crc
 
 cargo_check --target=thumbv7em-none-eabi --no-default-features
 cargo_check --target=thumbv7em-none-eabi --features=alloc,experimental-derive
+
+# CC https://github.com/jamesmunns/postcard/issues/167 - don't accidentally use atomics
+# on non-atomic systems
+cargo_check --target=riscv32i-unknown-none-elf --features=alloc,experimental-derive
 
 cargo fmt --all -- --check
 

--- a/source/postcard/src/max_size.rs
+++ b/source/postcard/src/max_size.rs
@@ -2,7 +2,10 @@
 extern crate alloc;
 
 #[cfg(feature = "alloc")]
-use alloc::{boxed::Box, rc::Rc, sync::Arc};
+use alloc::{boxed::Box, rc::Rc};
+
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+use alloc::sync::Arc;
 
 use crate::varint::varint_max;
 use core::{
@@ -204,8 +207,8 @@ impl<T: MaxSize> MaxSize for Box<T> {
     const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
 }
 
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", target_has_atomic = "ptr"))))]
 impl<T: MaxSize> MaxSize for Arc<T> {
     const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
 }
@@ -264,6 +267,8 @@ mod tests {
 
     use super::*;
     use alloc::rc::Rc;
+
+    #[cfg(target_has_atomic = "ptr")]
     use alloc::sync::Arc;
 
     #[test]
@@ -274,6 +279,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_has_atomic = "ptr")]
     fn arc_max_size() {
         assert_eq!(Arc::<u8>::POSTCARD_MAX_SIZE, 1);
         assert_eq!(Arc::<u32>::POSTCARD_MAX_SIZE, 5);


### PR DESCRIPTION
Resolving #167 cc: @jamesmunns 

When building with, _e.g._, `--target riscv32i-unknown-none-elf` and `-F alloc` on the current main branch, the build will fail with 

```
error[E0432]: unresolved import `alloc::sync`
 --> source/postcard/src/max_size.rs:5:33
  |
5 | use alloc::{boxed::Box, rc::Rc, sync::Arc};
  |                                 ^^^^ could not find `sync` in `alloc`
```

due to the lack of support on that target for atomic pointer operations (see: https://doc.rust-lang.org/alloc/sync/index.html).

Following the recommendation from the Rust docs, this gates definition of `POSTCARD_MAX_SIZE` for `alloc::sync::Arc` behind a configuration check to confirm it is available on the target first.