### PR TITLE
Implement a version of Schema types that are owned

### DIFF
--- a/source/postcard-derive/src/schema.rs
+++ b/source/postcard-derive/src/schema.rs
@@ -69,13 +69,21 @@ fn generate_struct(fields: &Fields) -> TokenStream {
             ]) }
         }
         syn::Fields::Unnamed(fields) => {
-            let fields = fields.unnamed.iter().map(|f| {
+            if fields.unnamed.len() == 1 {
+                let f = fields.unnamed[0].clone();
                 let ty = &f.ty;
-                quote_spanned!(f.span() => <#ty as ::postcard::experimental::schema::Schema>::SCHEMA)
-            });
-            quote! { &::postcard::experimental::schema::SdmTy::TupleStruct(&[
-                #( #fields ),*
-            ]) }
+                let qs = quote_spanned!(f.span() => <#ty as ::postcard::experimental::schema::Schema>::SCHEMA);
+
+                quote! { &::postcard::experimental::schema::SdmTy::NewtypeStruct(#qs) }
+            } else {
+                let fields = fields.unnamed.iter().map(|f| {
+                    let ty = &f.ty;
+                    quote_spanned!(f.span() => <#ty as ::postcard::experimental::schema::Schema>::SCHEMA)
+                });
+                quote! { &::postcard::experimental::schema::SdmTy::TupleStruct(&[
+                    #( #fields ),*
+                ]) }
+            }
         }
         syn::Fields::Unit => {
             quote! { &::postcard::experimental::schema::SdmTy::UnitStruct }
@@ -96,13 +104,21 @@ fn generate_variants(fields: &Fields) -> TokenStream {
             ]) }
         }
         syn::Fields::Unnamed(fields) => {
-            let fields = fields.unnamed.iter().map(|f| {
+            if fields.unnamed.len() == 1 {
+                let f = fields.unnamed[0].clone();
                 let ty = &f.ty;
-                quote_spanned!(f.span() => <#ty as ::postcard::experimental::schema::Schema>::SCHEMA)
-            });
-            quote! { &::postcard::experimental::schema::SdmTy::TupleVariant(&[
-                #( #fields ),*
-            ]) }
+                let qs = quote_spanned!(f.span() => <#ty as ::postcard::experimental::schema::Schema>::SCHEMA);
+
+                quote! { &::postcard::experimental::schema::SdmTy::NewtypeVariant(#qs) }
+            } else {
+                let fields = fields.unnamed.iter().map(|f| {
+                    let ty = &f.ty;
+                    quote_spanned!(f.span() => <#ty as ::postcard::experimental::schema::Schema>::SCHEMA)
+                });
+                quote! { &::postcard::experimental::schema::SdmTy::TupleVariant(&[
+                    #( #fields ),*
+                ]) }
+            }
         }
         syn::Fields::Unit => {
             quote! { &::postcard::experimental::schema::SdmTy::UnitVariant }

--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -71,6 +71,11 @@ version = "1.0"
 default-features = false
 optional = true
 
+[dependencies.chrono]
+version = "0.4"
+default-features = false
+optional = true
+
 [features]
 default = ["heapless-cas"]
 
@@ -89,6 +94,7 @@ use-defmt = ["defmt"]
 use-crc = ["crc", "paste"]
 
 uuid-v1_0 = ["uuid"]
+chrono-v0_4 = ["chrono"]
 
 # Experimental features!
 #

--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -66,6 +66,11 @@ optional = true
 version = "1.0.12"
 optional = true
 
+[dependencies.uuid]
+version = "1.0"
+default-features = false
+optional = true
+
 [features]
 default = ["heapless-cas"]
 
@@ -82,6 +87,8 @@ heapless-cas = ["heapless", "heapless/cas"]
 alloc = ["serde/alloc", "embedded-io-04?/alloc", "embedded-io-06?/alloc"]
 use-defmt = ["defmt"]
 use-crc = ["crc", "paste"]
+
+uuid-v1_0 = ["uuid"]
 
 # Experimental features!
 #

--- a/source/postcard/src/lib.rs
+++ b/source/postcard/src/lib.rs
@@ -81,6 +81,11 @@ pub mod experimental {
         pub use crate::schema::{NamedType, NamedValue, NamedVariant, Schema, SdmTy, Varint};
         // NOTE: ...and this is the derive macro
         pub use postcard_derive::Schema;
+
+        #[cfg(any(feature = "use-std", feature = "alloc"))]
+        pub use crate::schema::owned::{
+            OwnedNamedType, OwnedNamedValue, OwnedNamedVariant, OwnedSdmTy,
+        };
     }
 }
 

--- a/source/postcard/src/lib.rs
+++ b/source/postcard/src/lib.rs
@@ -83,8 +83,9 @@ pub mod experimental {
         pub use postcard_derive::Schema;
 
         #[cfg(any(feature = "use-std", feature = "alloc"))]
-        pub use crate::schema::owned::{
-            OwnedNamedType, OwnedNamedValue, OwnedNamedVariant, OwnedSdmTy,
+        pub use crate::schema::{
+            fmt::{fmt_owned_nt_to_buf, is_prim},
+            owned::{OwnedNamedType, OwnedNamedValue, OwnedNamedVariant, OwnedSdmTy},
         };
     }
 }

--- a/source/postcard/src/lib.rs
+++ b/source/postcard/src/lib.rs
@@ -87,6 +87,9 @@ pub mod experimental {
             fmt::{fmt_owned_nt_to_buf, is_prim},
             owned::{OwnedNamedType, OwnedNamedValue, OwnedNamedVariant, OwnedSdmTy},
         };
+
+        #[cfg(feature = "use-std")]
+        pub use crate::schema::fmt::{discover_tys, discover_tys_sdm};
     }
 }
 

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -352,7 +352,18 @@ impl Schema for NamedType {
 
 #[cfg(feature = "uuid-v1_0")]
 impl Schema for uuid::Uuid {
-    const SCHEMA: &'static NamedType = <[u8; 16]>::SCHEMA;
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "Uuid",
+        ty: <[u8; 16]>::SCHEMA.ty,
+    };
+}
+
+#[cfg(feature = "chrono-v0_4")]
+impl<Tz: chrono::TimeZone> Schema for chrono::DateTime<Tz> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "DateTime",
+        ty: <&str>::SCHEMA.ty,
+    };
 }
 
 #[cfg(any(feature = "use-std", feature = "alloc"))]

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -102,7 +102,7 @@ pub enum SdmTy {
     /// The "Enum" Serde Data Model Type (which contains any of the "Variant" types)
     Enum(&'static [&'static NamedVariant]),
 
-    // A NamedType/OwnedNamedType
+    /// A NamedType/OwnedNamedType
     Schema,
 }
 
@@ -350,6 +350,11 @@ impl Schema for NamedType {
     };
 }
 
+#[cfg(feature = "uuid-v1_0")]
+impl Schema for uuid::Uuid {
+    const SCHEMA: &'static NamedType = <[u8; 16]>::SCHEMA;
+}
+
 #[cfg(any(feature = "use-std", feature = "alloc"))]
 pub(crate) mod owned {
     use super::*;
@@ -441,7 +446,7 @@ pub(crate) mod owned {
         /// The "Enum" Serde Data Model Type (which contains any of the "Variant" types)
         Enum(Vec<OwnedNamedVariant>),
 
-        // A NamedType/OwnedNamedType
+        /// A NamedType/OwnedNamedType
         Schema,
     }
 

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -1,3 +1,7 @@
+use core::num::{
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+    NonZeroU32, NonZeroU64, NonZeroU8,
+};
 use serde::{Deserialize, Serialize};
 
 /// A schema type representing a variably encoded integer
@@ -168,7 +172,9 @@ macro_rules! impl_schema {
 
 impl_schema![
     u8: SdmTy::U8,
+    NonZeroU8: SdmTy::U8,
     i8: SdmTy::I8,
+    NonZeroI8: SdmTy::I8,
     bool: SdmTy::Bool,
     f32: SdmTy::F32,
     f64: SdmTy::F64,
@@ -178,7 +184,11 @@ impl_schema![
 ];
 impl_schema!(varint => [
     i16: Varint::I16, i32: Varint::I32, i64: Varint::I64, i128: Varint::I128,
-    u16: Varint::U16, u32: Varint::U32, u64: Varint::U64, u128: Varint::U128
+    u16: Varint::U16, u32: Varint::U32, u64: Varint::U64, u128: Varint::U128,
+    NonZeroI16: Varint::I16, NonZeroI32: Varint::I32,
+    NonZeroI64: Varint::I64, NonZeroI128: Varint::I128,
+    NonZeroU16: Varint::U16, NonZeroU32: Varint::U32,
+    NonZeroU64: Varint::U64, NonZeroU128: Varint::U128
 ]);
 impl_schema!(tuple => [
     (A),
@@ -835,9 +845,7 @@ pub(crate) mod fmt {
                     *buf += &ont.name;
                 }
             }
-            OwnedSdmTy::Schema => {
-                *buf += "Schema"
-            }
+            OwnedSdmTy::Schema => *buf += "Schema",
 
             // We only handle variants as part of an enum
             OwnedSdmTy::UnitVariant => unreachable!(),

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -563,7 +563,7 @@ pub(crate) mod owned {
         }
     }
 
-    impl Schema for OwnedNamedValue {
+    impl Schema for OwnedNamedType {
         const SCHEMA: &'static NamedType = &NamedType {
             name: "OwnedNamedType",
             ty: &SdmTy::Schema,

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -56,7 +56,7 @@ pub enum SdmTy {
     /// The `String` Serde Data Model Type
     String,
 
-    /// The `[u8; N]` Serde Data Model Type
+    /// The `&[u8]` Serde Data Model Type
     ByteArray,
 
     /// The `Option<T>` Serde Data Model Type
@@ -364,7 +364,7 @@ impl Schema for NamedType {
 impl Schema for uuid::Uuid {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "Uuid",
-        ty: <[u8; 16]>::SCHEMA.ty,
+        ty: &SdmTy::ByteArray,
     };
 }
 
@@ -417,7 +417,7 @@ pub(crate) mod owned {
         /// The `String` Serde Data Model Type
         String,
 
-        /// The `[u8; N]` Serde Data Model Type
+        /// The `&[u8]` Serde Data Model Type
         ByteArray,
 
         /// The `Option<T>` Serde Data Model Type

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -260,6 +260,48 @@ impl Schema for std::string::String {
     };
 }
 
+#[cfg(feature = "use-std")]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<K: Schema, V: Schema> Schema for std::collections::HashMap<K, V> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "HashMap<K, V>",
+        ty: &SdmTy::Map {
+            key: K::SCHEMA,
+            val: V::SCHEMA,
+        },
+    };
+}
+
+#[cfg(feature = "use-std")]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<K: Schema, V: Schema> Schema for std::collections::BTreeMap<K, V> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "BTreeMap<K, V>",
+        ty: &SdmTy::Map {
+            key: K::SCHEMA,
+            val: V::SCHEMA,
+        },
+    };
+}
+
+#[cfg(feature = "use-std")]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<K: Schema> Schema for std::collections::HashSet<K> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "HashSet<K>",
+        ty: &SdmTy::Seq(K::SCHEMA),
+    };
+}
+
+#[cfg(feature = "use-std")]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<K: Schema> Schema for std::collections::BTreeSet<K> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "BTreeSet<K>",
+        ty: &SdmTy::Seq(K::SCHEMA),
+    };
+}
+
 #[cfg(all(not(feature = "use-std"), feature = "alloc"))]
 extern crate alloc;
 
@@ -276,6 +318,25 @@ impl Schema for alloc::string::String {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "String",
         ty: &SdmTy::String,
+    };
+}
+
+#[cfg(all(not(feature = "use-std"), feature = "alloc"))]
+impl<K: Schema, V: Schema> Schema for alloc::collections::BTreeMap<K, V> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "BTreeMap<K, V>",
+        ty: &SdmTy::Map {
+            key: K::SCHEMA,
+            val: V::SCHEMA,
+        },
+    };
+}
+
+#[cfg(all(not(feature = "use-std"), feature = "alloc"))]
+impl<K: Schema> Schema for alloc::collections::BTreeSet<K> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "BTreeSet<K>",
+        ty: &SdmTy::Seq(K::SCHEMA),
     };
 }
 

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -1,7 +1,7 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A schema type representing a variably encoded integer
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Varint {
     /// A variably encoded i16
     I16,
@@ -26,7 +26,7 @@ pub enum Varint {
 }
 
 /// Serde Data Model Types (and friends)
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum SdmTy {
     /// The `bool` Serde Data Model Type
     Bool,
@@ -104,7 +104,7 @@ pub enum SdmTy {
 }
 
 /// A data type with a name - e.g. a field of a Struct
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct NamedValue {
     /// The name of this value
     pub name: &'static str,
@@ -113,7 +113,7 @@ pub struct NamedValue {
 }
 
 /// A data type - e.g. a custom `struct Foo{ ... }` type
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct NamedType {
     /// The name of this type
     pub name: &'static str,
@@ -122,7 +122,7 @@ pub struct NamedType {
 }
 
 /// An enum variant with a name, e.g. `T::Bar(...)`
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct NamedVariant {
     /// The name of this variant
     pub name: &'static str,
@@ -277,4 +277,190 @@ impl Schema for alloc::string::String {
         name: "String",
         ty: &SdmTy::String,
     };
+}
+
+#[cfg(any(feature = "use-std", feature = "alloc"))]
+pub(crate) mod owned {
+    use super::*;
+
+    #[cfg(feature = "use-std")]
+    use std::{boxed::Box, string::String, vec::Vec};
+
+    #[cfg(all(not(feature = "use-std"), feature = "alloc"))]
+    use alloc::{
+        boxed::Box,
+        string::{String, ToString},
+        vec::Vec,
+    };
+
+    /// Serde Data Model Types (and friends)
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    pub enum OwnedSdmTy {
+        /// The `bool` Serde Data Model Type
+        Bool,
+
+        /// The `i8` Serde Data Model Type
+        I8,
+
+        /// The `u8` Serde Data Model Type
+        U8,
+
+        /// The Serde Data Model Type for variably length encoded integers
+        Varint(Varint),
+
+        /// The `f32` Serde Data Model Type
+        F32,
+
+        /// The `f64 Serde Data Model Type
+        F64,
+
+        /// The `char` Serde Data Model Type
+        Char,
+
+        /// The `String` Serde Data Model Type
+        String,
+
+        /// The `[u8; N]` Serde Data Model Type
+        ByteArray,
+
+        /// The `Option<T>` Serde Data Model Type
+        Option(Box<OwnedNamedType>),
+
+        /// The `()` Serde Data Model Type
+        Unit,
+
+        /// The "unit struct" Serde Data Model Type
+        UnitStruct,
+
+        /// The "unit variant" Serde Data Model Type
+        UnitVariant,
+
+        /// The "newtype struct" Serde Data Model Type
+        NewtypeStruct(Box<OwnedNamedType>),
+
+        /// The "newtype variant" Serde Data Model Type
+        NewtypeVariant(Box<OwnedNamedType>),
+
+        /// The "Sequence" Serde Data Model Type
+        Seq(Box<OwnedNamedType>),
+
+        /// The "Tuple" Serde Data Model Type
+        Tuple(Vec<OwnedNamedType>),
+
+        /// The "Tuple Struct" Serde Data Model Type
+        TupleStruct(Vec<OwnedNamedType>),
+
+        /// The "Tuple Variant" Serde Data Model Type
+        TupleVariant(Vec<OwnedNamedType>),
+
+        /// The "Map" Serde Data Model Type
+        Map {
+            /// The map "Key" type
+            key: Box<OwnedNamedType>,
+            /// The map "Value" type
+            val: Box<OwnedNamedType>,
+        },
+
+        /// The "Struct" Serde Data Model Type
+        Struct(Vec<OwnedNamedValue>),
+
+        /// The "Struct Variant" Serde Data Model Type
+        StructVariant(Vec<OwnedNamedValue>),
+
+        /// The "Enum" Serde Data Model Type (which contains any of the "Variant" types)
+        Enum(Vec<OwnedNamedVariant>),
+    }
+
+    impl From<&SdmTy> for OwnedSdmTy {
+        fn from(other: &SdmTy) -> Self {
+            match other {
+                SdmTy::Bool => Self::Bool,
+                SdmTy::I8 => Self::I8,
+                SdmTy::U8 => Self::U8,
+                SdmTy::Varint(v) => Self::Varint(*v),
+                SdmTy::F32 => Self::F32,
+                SdmTy::F64 => Self::F64,
+                SdmTy::Char => Self::Char,
+                SdmTy::String => Self::String,
+                SdmTy::ByteArray => Self::ByteArray,
+                SdmTy::Option(o) => Self::Option(Box::new((*o).into())),
+                SdmTy::Unit => Self::Unit,
+                SdmTy::UnitStruct => Self::UnitStruct,
+                SdmTy::UnitVariant => Self::UnitVariant,
+                SdmTy::NewtypeStruct(nts) => Self::NewtypeStruct(Box::new((*nts).into())),
+                SdmTy::NewtypeVariant(ntv) => Self::NewtypeVariant(Box::new((*ntv).into())),
+                SdmTy::Seq(s) => Self::Seq(Box::new((*s).into())),
+                SdmTy::Tuple(t) => Self::Tuple(t.iter().map(|i| (*i).into()).collect()),
+                SdmTy::TupleStruct(ts) => {
+                    Self::TupleStruct(ts.iter().map(|i| (*i).into()).collect())
+                }
+                SdmTy::TupleVariant(tv) => {
+                    Self::TupleVariant(tv.iter().map(|i| (*i).into()).collect())
+                }
+                SdmTy::Map { key, val } => Self::Map {
+                    key: Box::new((*key).into()),
+                    val: Box::new((*val).into()),
+                },
+                SdmTy::Struct(s) => Self::Struct(s.iter().map(|i| (*i).into()).collect()),
+                SdmTy::StructVariant(sv) => {
+                    Self::StructVariant(sv.iter().map(|i| (*i).into()).collect())
+                }
+                SdmTy::Enum(e) => Self::Enum(e.iter().map(|i| (*i).into()).collect()),
+            }
+        }
+    }
+
+    /// A data type with a name - e.g. a field of a Struct
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    pub struct OwnedNamedValue {
+        /// The name of this value
+        pub name: String,
+        /// The type of this value
+        pub ty: OwnedNamedType,
+    }
+
+    impl From<&NamedValue> for OwnedNamedValue {
+        fn from(value: &NamedValue) -> Self {
+            Self {
+                name: value.name.to_string(),
+                ty: value.ty.into(),
+            }
+        }
+    }
+
+    /// A data type - e.g. a custom `struct Foo{ ... }` type
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    pub struct OwnedNamedType {
+        /// The name of this type
+        pub name: String,
+        /// The type
+        pub ty: OwnedSdmTy,
+    }
+
+    impl From<&NamedType> for OwnedNamedType {
+        fn from(value: &NamedType) -> Self {
+            Self {
+                name: value.name.to_string(),
+                ty: value.ty.into(),
+            }
+        }
+    }
+
+    /// An enum variant with a name, e.g. `T::Bar(...)`
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    pub struct OwnedNamedVariant {
+        /// The name of this variant
+        pub name: String,
+        /// The type of this variant
+        pub ty: OwnedSdmTy,
+    }
+
+    impl From<&NamedVariant> for OwnedNamedVariant {
+        fn from(value: &NamedVariant) -> Self {
+            Self {
+                name: value.name.to_string(),
+                ty: value.ty.into(),
+            }
+        }
+    }
 }

--- a/source/postcard/tests/schema.rs
+++ b/source/postcard/tests/schema.rs
@@ -203,7 +203,7 @@ fn owned_punning() {
 
     // TODO: This is wildly repetitive, and likely could benefit from interning of
     // repeated types, strings, etc.
-    assert_eq!(ser_borrowed_schema.len(), 282);
+    assert_eq!(ser_borrowed_schema.len(), 280);
 
     // Check that we round-trip correctly
     let deser_borrowed_schema =
@@ -212,4 +212,49 @@ fn owned_punning() {
     assert_eq!(deser_borrowed_schema, deser_owned_schema);
     assert_eq!(deser_borrowed_schema, owned_schema);
     assert_eq!(deser_owned_schema, owned_schema);
+}
+
+#[allow(unused)]
+#[derive(Debug, Schema)]
+struct TestStruct3(u64);
+
+#[allow(unused)]
+#[derive(Debug, Schema)]
+struct TestStruct4(u64, bool);
+
+#[allow(unused)]
+#[derive(Debug, Schema)]
+enum TestEnum2 {
+    Nt(u64),
+    Tup(u64, bool),
+}
+
+#[test]
+fn newtype_vs_tuple() {
+    assert_eq!(
+        TestStruct3::SCHEMA,
+        &NamedType {
+            name: "TestStruct3",
+            ty: &SdmTy::NewtypeStruct(u64::SCHEMA)
+        }
+    );
+
+    assert_eq!(
+        TestStruct4::SCHEMA,
+        &NamedType {
+            name: "TestStruct4",
+            ty: &SdmTy::TupleStruct(&[u64::SCHEMA, bool::SCHEMA]),
+        }
+    );
+
+    assert_eq!(
+        TestEnum2::SCHEMA,
+        &NamedType {
+            name: "TestEnum2",
+            ty: &SdmTy::Enum(&[
+                &NamedVariant { name: "Nt", ty: &SdmTy::NewtypeVariant(u64::SCHEMA) },
+                &NamedVariant { name: "Tup", ty: &SdmTy::TupleVariant(&[u64::SCHEMA, bool::SCHEMA]) },
+            ]),
+        }
+    );
 }

--- a/source/postcard/tests/schema.rs
+++ b/source/postcard/tests/schema.rs
@@ -269,9 +269,7 @@ fn newtype_vs_tuple() {
 
 fn dewit<T: Schema>() -> String {
     let schema: OwnedNamedType = T::SCHEMA.into();
-    let mut buf = String::new();
-    ugh_ont(&schema, &mut buf, true);
-    buf
+    schema.to_pseudocode()
 }
 
 #[derive(Schema)]
@@ -337,8 +335,8 @@ fn smoke() {
         (dewit::<(u8, u16, u32)>, "(u8, u16, u32)"),
         (dewit::<TupStruct>, "struct TupStruct(u64, String)"),
         (dewit::<Option<TupStruct>>, "Option<TupStruct>"),
-        (dewit::<HashMap<u32, String>>, "Map<u32, String>"),
-        (dewit::<HashSet<u32>>, "[u32]"),
+        (dewit::<std::collections::HashMap<u32, String>>, "Map<u32, String>"),
+        (dewit::<std::collections::HashSet<u32>>, "[u32]"),
         (
             dewit::<Classic>,
             "struct Classic { a: u32, b: u16, c: bool }",

--- a/source/postcard/tests/schema.rs
+++ b/source/postcard/tests/schema.rs
@@ -264,3 +264,93 @@ fn newtype_vs_tuple() {
         }
     );
 }
+
+// Formatting
+
+fn dewit<T: Schema>() -> String {
+    let schema: OwnedNamedType = T::SCHEMA.into();
+    let mut buf = String::new();
+    ugh_ont(&schema, &mut buf, true);
+    buf
+}
+
+#[derive(Schema)]
+struct UnitStruct;
+
+#[derive(Schema)]
+struct NewTypeStruct(String);
+
+#[derive(Schema)]
+struct TupStruct(u64, String);
+
+#[derive(Schema)]
+enum Enums {
+    Unit,
+    Nt(u64),
+    Tup(u32, bool),
+}
+
+#[derive(Schema)]
+struct Classic {
+    a: u32,
+    b: u16,
+    c: bool,
+}
+
+#[derive(Schema)]
+struct ClassicGen<T: Schema> {
+    a: u32,
+    b: T,
+}
+
+#[test]
+fn smoke() {
+    #[allow(clippy::type_complexity)]
+    let tests: &[(fn() -> String, &str)] = &[
+        (dewit::<u8>, "u8"),
+        (dewit::<u16>, "u16"),
+        (dewit::<u32>, "u32"),
+        (dewit::<u64>, "u64"),
+        (dewit::<u128>, "u128"),
+        (dewit::<i8>, "i8"),
+        (dewit::<i16>, "i16"),
+        (dewit::<i32>, "i32"),
+        (dewit::<i64>, "i64"),
+        (dewit::<i128>, "i128"),
+        (dewit::<()>, "()"),
+        (dewit::<char>, "char"),
+        (dewit::<bool>, "bool"),
+        (dewit::<String>, "String"),
+        (dewit::<Option<u16>>, "Option<u16>"),
+        (dewit::<UnitStruct>, "struct UnitStruct"),
+        (dewit::<Option<UnitStruct>>, "Option<UnitStruct>"),
+        (dewit::<NewTypeStruct>, "struct NewTypeStruct(String)"),
+        (dewit::<Option<NewTypeStruct>>, "Option<NewTypeStruct>"),
+        (
+            dewit::<Enums>,
+            "enum Enums { Unit, Nt(u64), Tup(u32, bool) }",
+        ),
+        (dewit::<Option<Enums>>, "Option<Enums>"),
+        (dewit::<&[u8]>, "[u8]"),
+        (dewit::<Vec<u16>>, "[u16]"),
+        (dewit::<[u8; 16]>, "[u8; 16]"),
+        (dewit::<(u8, u16, u32)>, "(u8, u16, u32)"),
+        (dewit::<TupStruct>, "struct TupStruct(u64, String)"),
+        (dewit::<Option<TupStruct>>, "Option<TupStruct>"),
+        (dewit::<HashMap<u32, String>>, "Map<u32, String>"),
+        (dewit::<HashSet<u32>>, "[u32]"),
+        (
+            dewit::<Classic>,
+            "struct Classic { a: u32, b: u16, c: bool }",
+        ),
+        (
+            dewit::<ClassicGen<i32>>,
+            "struct ClassicGen { a: u32, b: i32 }",
+        ),
+        (dewit::<Option<Classic>>, "Option<Classic>"),
+        (dewit::<Option<ClassicGen<i32>>>, "Option<ClassicGen>"),
+    ];
+    for (f, s) in tests {
+        assert_eq!(f().as_str(), *s);
+    }
+}

--- a/source/postcard/tests/schema.rs
+++ b/source/postcard/tests/schema.rs
@@ -272,15 +272,19 @@ fn dewit<T: Schema>() -> String {
     schema.to_pseudocode()
 }
 
+#[allow(unused)]
 #[derive(Schema)]
 struct UnitStruct;
 
+#[allow(unused)]
 #[derive(Schema)]
 struct NewTypeStruct(String);
 
+#[allow(unused)]
 #[derive(Schema)]
 struct TupStruct(u64, String);
 
+#[allow(unused)]
 #[derive(Schema)]
 enum Enums {
     Unit,
@@ -288,6 +292,7 @@ enum Enums {
     Tup(u32, bool),
 }
 
+#[allow(unused)]
 #[derive(Schema)]
 struct Classic {
     a: u32,
@@ -295,6 +300,7 @@ struct Classic {
     c: bool,
 }
 
+#[allow(unused)]
 #[derive(Schema)]
 struct ClassicGen<T: Schema> {
     a: u32,
@@ -335,7 +341,10 @@ fn smoke() {
         (dewit::<(u8, u16, u32)>, "(u8, u16, u32)"),
         (dewit::<TupStruct>, "struct TupStruct(u64, String)"),
         (dewit::<Option<TupStruct>>, "Option<TupStruct>"),
-        (dewit::<std::collections::HashMap<u32, String>>, "Map<u32, String>"),
+        (
+            dewit::<std::collections::HashMap<u32, String>>,
+            "Map<u32, String>",
+        ),
         (dewit::<std::collections::HashSet<u32>>, "[u32]"),
         (
             dewit::<Classic>,

--- a/source/postcard/tests/schema.rs
+++ b/source/postcard/tests/schema.rs
@@ -252,8 +252,14 @@ fn newtype_vs_tuple() {
         &NamedType {
             name: "TestEnum2",
             ty: &SdmTy::Enum(&[
-                &NamedVariant { name: "Nt", ty: &SdmTy::NewtypeVariant(u64::SCHEMA) },
-                &NamedVariant { name: "Tup", ty: &SdmTy::TupleVariant(&[u64::SCHEMA, bool::SCHEMA]) },
+                &NamedVariant {
+                    name: "Nt",
+                    ty: &SdmTy::NewtypeVariant(u64::SCHEMA)
+                },
+                &NamedVariant {
+                    name: "Tup",
+                    ty: &SdmTy::TupleVariant(&[u64::SCHEMA, bool::SCHEMA])
+                },
             ]),
         }
     );


### PR DESCRIPTION
These types are use the heap to handle the recursive nature of schemas, and can be punned or converted with existing typed or serialized schema types.

For now, the serialized form is fairly inefficient: types and names are repeated instead of being interned or deduplicated in any way.