### PR TITLE
chore: pin exact version of `heapless`

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 
 [dependencies.heapless]
-version = "0.7.0"
+version = "~0.7.0"
 default-features = false
 features = ["serde"]
 optional = true


### PR DESCRIPTION
For the moment the `heapless` crate is locked on 0.7.0, because 0.8.0 still requires some work (the revert happened with #164). The problem is that the "0.7.0" version requirement also matches "0.8.0", so for the moment we need "~0.7.0" to not allow a minor version update (which would brake the package).