### PR TITLE
Corrected invalid link in `Serializer` docs

### DIFF
--- a/source/postcard/src/ser/serializer.rs
+++ b/source/postcard/src/ser/serializer.rs
@@ -11,7 +11,7 @@ use crate::varint::*;
 ///
 /// See the docs for [`SerFlavor`] for more information about "flavors" of serialization
 ///
-/// [`SerFlavor`]: trait.SerFlavor.html
+/// [`SerFlavor`]: crate::ser_flavors::Flavor
 pub struct Serializer<F>
 where
     F: Flavor,


### PR DESCRIPTION
There is a broken link in the docs for the `Serializer`. The intended link seems to be to `crate::ser_flavors::Flavor`.