### PR TITLE
Add support for skipped fields

### DIFF
--- a/source/postcard/src/ser/serializer.rs
+++ b/source/postcard/src/ser/serializer.rs
@@ -521,6 +521,11 @@ where
     }
 
     #[inline]
+    fn skip_field(&mut self, _key: &'static str) -> Result<()> {
+        None::<()>.serialize(&mut **self)
+    }
+
+    #[inline]
     fn end(self) -> Result<()> {
         Ok(())
     }
@@ -539,6 +544,11 @@ where
         T: ?Sized + Serialize,
     {
         value.serialize(&mut **self)
+    }
+
+    #[inline]
+    fn skip_field(&mut self, _key: &'static str) -> Result<()> {
+        None::<()>.serialize(&mut **self)
     }
 
     #[inline]

--- a/source/postcard/tests/skiped_fields.rs
+++ b/source/postcard/tests/skiped_fields.rs
@@ -1,0 +1,109 @@
+use std::marker::PhantomData;
+
+#[cfg(feature = "heapless")]
+use heapless::Vec;
+
+use postcard::from_bytes;
+#[cfg(feature = "heapless")]
+use postcard::to_vec;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct A {
+    a: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b: Option<u8>,
+    c: u8,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum E {
+    A(A),
+    B {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        b: Option<u64>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct C {
+    #[serde(skip)]
+    ghost: u8,
+    phantom: PhantomData<u16>,
+}
+
+#[test]
+#[cfg(feature = "heapless")]
+fn complete() {
+    let a = A {
+        a: 0xA,
+        b: Some(0xB),
+        c: 0xC,
+    };
+
+    let bytes: Vec<u8, 42> = to_vec(&a).expect("unable to serialize");
+
+    let restored: A = from_bytes(&bytes).expect("unable to deserialize");
+
+    assert_eq!(a, restored);
+}
+
+#[test]
+#[cfg(feature = "heapless")]
+fn partial_struct() {
+    let a = A {
+        a: 0xA,
+        b: None,
+        c: 0xC,
+    };
+
+    let bytes: Vec<u8, 42> = to_vec(&a).expect("unable to serialize");
+
+    let restored: A = from_bytes(&bytes).expect("unable to deserialize");
+
+    assert_eq!(a, restored);
+}
+
+#[test]
+#[cfg(feature = "heapless")]
+fn partial_enum_a() {
+    let e = E::A(A {
+        a: 0xA,
+        b: None,
+        c: 0xC,
+    });
+
+    let bytes: Vec<u8, 42> = to_vec(&e).expect("unable to serialize");
+
+    let restored: E = from_bytes(&bytes).expect("unable to deserialize");
+
+    assert_eq!(e, restored);
+}
+
+#[test]
+#[cfg(feature = "heapless")]
+fn partial_enum_b() {
+    let e = E::B { b: None };
+
+    let bytes: Vec<u8, 42> = to_vec(&e).expect("unable to serialize");
+
+    let restored: E = from_bytes(&bytes).expect("unable to deserialize");
+
+    assert_eq!(e, restored);
+}
+
+#[test]
+#[cfg(feature = "heapless")]
+fn empty_struct_unconditional() {
+    let c = C::default();
+
+    let bytes: Vec<u8, 42> = to_vec(&c).expect("unable to serialize");
+
+    assert_eq!(0, bytes.len());
+    //assert!(false, "{:?}", bytes);
+
+    let restored: C = from_bytes(&bytes).expect("unable to deserialize");
+
+    assert_eq!(c, restored);
+}


### PR DESCRIPTION
Hi all

I made this PR to support maybe skipped fields, either always or dynamically with `#[serde(skip_serializing_if = "Option::is_none")]`.

I have considered hiding the function behind a feature flag and adding a runtime Err without the flag so consumers of the crate notice that they were trying to serialize an object that would not be readable again.

Looking forward hearing from you,
Stefan

PS: I assume that `None::<()>` takes the same amount of space as `None::<u128>` or something else would and that trick then allows us to stay with the wire format, 99% sure of that, happy to learn :blush: 
