### PR TITLE
Implement Schema for nalgebra matrix type

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -69,6 +69,7 @@ optional = true
 [dependencies.nalgebra]
 version = "0.33.0"
 optional = true
+default-features = false
 
 [features]
 default = ["heapless-cas"]

--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -66,6 +66,10 @@ optional = true
 version = "1.0.12"
 optional = true
 
+[dependencies.nalgebra]
+version = "0.33.0"
+optional = true
+
 [features]
 default = ["heapless-cas"]
 

--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -66,7 +66,8 @@ optional = true
 version = "1.0.12"
 optional = true
 
-[dependencies.nalgebra]
+[dependencies.nalgebra-0_33]
+package = "nalgebra"
 version = "0.33.0"
 optional = true
 default-features = false
@@ -81,6 +82,9 @@ embedded-io = ["dep:embedded-io-04"]
 # Specific versions of `embedded-io` can be selected through the features below
 embedded-io-04 = ["dep:embedded-io-04"]
 embedded-io-06 = ["dep:embedded-io-06"]
+
+# Specific versions of `nalgebra` can be selected through the features below
+nalgebra-0_33 = ["dep:nalgebra-0_33"]
 
 use-std = ["serde/std", "alloc"]
 heapless-cas = ["heapless", "heapless/cas"]

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -260,12 +260,17 @@ impl Schema for std::string::String {
     };
 }
 
-#[cfg(feature = "nalgebra")]
-#[cfg_attr(docsrs, doc(cfg(feature = "nalgebra")))]
+#[cfg(feature = "nalgebra-0_33")]
+#[cfg_attr(docsrs, doc(cfg(feature = "nalgebra-0_33")))]
 impl<T, const R: usize, const C: usize> Schema
-    for nalgebra::Matrix<T, nalgebra::Const<R>, nalgebra::Const<C>, nalgebra::ArrayStorage<T, R, C>>
+    for nalgebra_0_33::Matrix<
+        T,
+        nalgebra_0_33::Const<R>,
+        nalgebra_0_33::Const<C>,
+        nalgebra_0_33::ArrayStorage<T, R, C>,
+    >
 where
-    T: Schema + nalgebra::Scalar,
+    T: Schema + nalgebra_0_33::Scalar,
 {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "nalgebra::Matrix<T, R, C, ArrayStorage<T, R, C>>",

--- a/source/postcard/src/schema.rs
+++ b/source/postcard/src/schema.rs
@@ -260,6 +260,19 @@ impl Schema for std::string::String {
     };
 }
 
+#[cfg(feature = "nalgebra")]
+#[cfg_attr(docsrs, doc(cfg(feature = "nalgebra")))]
+impl<T, const R: usize, const C: usize> Schema
+    for nalgebra::Matrix<T, nalgebra::Const<R>, nalgebra::Const<C>, nalgebra::ArrayStorage<T, R, C>>
+where
+    T: Schema + nalgebra::Scalar,
+{
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "nalgebra::Matrix<T, R, C, ArrayStorage<T, R, C>>",
+        ty: &SdmTy::Seq(T::SCHEMA),
+    };
+}
+
 #[cfg(all(not(feature = "use-std"), feature = "alloc"))]
 extern crate alloc;
 


### PR DESCRIPTION
I want to send some nalgebra types over the wire using postcard-rpc so I needed to implement the `Schema` trait. Initially I used a newtype to get around the orphan rule but in this case that's quite annoying because it requires copying a _huge_ API into my own project.

I figured `nalgebra` is a somewhat foundational crate in the Rust ecosystem to I think it is acceptable to add it an an optional dependency here.