### PR TITLE
Fix nalgebra schema

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -29,7 +29,7 @@ cargo_test() {
   cargo test --all "$@"
 }
 
-cargo_test --features=alloc,experimental-derive,use-std,use-crc,derive
+cargo_test --features=alloc,experimental-derive,use-std,use-crc,derive,nalgebra-v0_33
 
 # NOTE: we exclude postcard-dyn for these checks because it is std-only
 

--- a/source/postcard-schema/Cargo.toml
+++ b/source/postcard-schema/Cargo.toml
@@ -68,6 +68,12 @@ path = "../postcard"
 version = "1.0"
 features = ["use-std"]
 
+[dev-dependencies.nalgebra_v0_33]
+package = "nalgebra"
+version = "0.33.0"
+default-features = false
+features = ["serde-serialize-no-std"]
+
 [features]
 default = []
 use-std = ["serde/std"]

--- a/source/postcard-schema/src/impls/nalgebra_v0_33.rs
+++ b/source/postcard-schema/src/impls/nalgebra_v0_33.rs
@@ -18,6 +18,31 @@ where
 {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "nalgebra::Matrix<T, R, C, ArrayStorage<T, R, C>>",
-        ty: &DataModelType::Seq(T::SCHEMA),
+        ty: &DataModelType::Tuple(flatten(&[[T::SCHEMA; R]; C])),
     };
+}
+
+/// Const version of the const-unstable [`<[[T; N]]>::as_flattened()`]
+const fn flatten<T, const N: usize>(slice: &[[T; N]]) -> &[T] {
+    const {
+        assert!(size_of::<T>() != 0);
+    }
+    // SAFETY: `self.len() * N` cannot overflow because `self` is
+    // already in the address space.
+    let len = unsafe { slice.len().unchecked_mul(N) };
+    // SAFETY: `[T]` is layout-identical to `[T; N]`
+    unsafe { core::slice::from_raw_parts(slice.as_ptr().cast(), len) }
+}
+
+#[test]
+fn flattened() {
+    type T = nalgebra_v0_33::SMatrix<u8, 3, 3>;
+    assert_eq!(T::SCHEMA.ty, <[u8; 9]>::SCHEMA.ty);
+}
+
+#[test]
+fn smoke() {
+    let x = nalgebra_v0_33::SMatrix::<u8, 3, 3>::new(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    let y = postcard::to_stdvec(&x).unwrap();
+    assert_eq!(&[1, 4, 7, 2, 5, 8, 3, 6, 9], y.as_slice());
 }


### PR DESCRIPTION
Closes #181, using a slice-of-array flattening function borrowed from the const-unstable [`<[[T; N]]>::as_flattened()`](https://doc.rust-lang.org/core/primitive.slice.html#method.as_flattened)