### PR TITLE
Fix EOF not being handled correctly

### DIFF
--- a/source/postcard/src/de/flavors.rs
+++ b/source/postcard/src/de/flavors.rs
@@ -283,7 +283,7 @@ pub mod io {
             fn pop(&mut self) -> Result<u8> {
                 let mut val = [0; 1];
                 self.reader
-                    .read(&mut val)
+                    .read_exact(&mut val)
                     .map_err(|_| Error::DeserializeUnexpectedEnd)?;
                 Ok(val[0])
             }
@@ -353,7 +353,7 @@ pub mod io {
             fn pop(&mut self) -> Result<u8> {
                 let mut val = [0; 1];
                 self.reader
-                    .read(&mut val)
+                    .read_exact(&mut val)
                     .map_err(|_| Error::DeserializeUnexpectedEnd)?;
                 Ok(val[0])
             }

--- a/source/postcard/src/de/flavors.rs
+++ b/source/postcard/src/de/flavors.rs
@@ -308,6 +308,31 @@ pub mod io {
                 Ok((self.reader, buf))
             }
         }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+
+            #[test]
+            fn test_pop() {
+                let mut reader = EIOReader::new(&[0xAA, 0xBB, 0xCC][..], &mut []);
+
+                assert_eq!(reader.pop(), Ok(0xAA));
+                assert_eq!(reader.pop(), Ok(0xBB));
+                assert_eq!(reader.pop(), Ok(0xCC));
+                assert_eq!(reader.pop(), Err(Error::DeserializeUnexpectedEnd));
+            }
+
+            #[test]
+            fn test_try_take_n() {
+                let mut buf = [0; 8];
+                let mut reader = EIOReader::new(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE][..], &mut buf);
+
+                assert_eq!(reader.try_take_n(2), Ok(&[0xAA, 0xBB][..]));
+                assert_eq!(reader.try_take_n(2), Ok(&[0xCC, 0xDD][..]));
+                assert_eq!(reader.try_take_n(2), Err(Error::DeserializeUnexpectedEnd));
+            }
+        }
     }
 
     /// Support for [`std::io`] traits
@@ -376,6 +401,31 @@ pub mod io {
             fn finalize(self) -> Result<(T, &'de mut [u8])> {
                 let buf = self.buff.complete()?;
                 Ok((self.reader, buf))
+            }
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+
+            #[test]
+            fn test_pop() {
+                let mut reader = IOReader::new(&[0xAA, 0xBB, 0xCC][..], &mut []);
+
+                assert_eq!(reader.pop(), Ok(0xAA));
+                assert_eq!(reader.pop(), Ok(0xBB));
+                assert_eq!(reader.pop(), Ok(0xCC));
+                assert_eq!(reader.pop(), Err(Error::DeserializeUnexpectedEnd));
+            }
+
+            #[test]
+            fn test_try_take_n() {
+                let mut buf = [0; 8];
+                let mut reader = IOReader::new(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE][..], &mut buf);
+
+                assert_eq!(reader.try_take_n(2), Ok(&[0xAA, 0xBB][..]));
+                assert_eq!(reader.try_take_n(2), Ok(&[0xCC, 0xDD][..]));
+                assert_eq!(reader.try_take_n(2), Err(Error::DeserializeUnexpectedEnd));
             }
         }
     }


### PR DESCRIPTION
In `IOReader` and `EIOReader`, `pop()` does not properly handle EOF. The `read()` methods return `Ok(0)` when reaching the end of the file:

- https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read
- https://docs.rs/embedded-io/latest/embedded_io/trait.Read.html#tymethod.read

Switched to using `read_exact()`, which returns an `Err` if EOF is reached, which is what the code seems to expect.