### PR TITLE
`postcard-schema`: restructure schema type hierarchy

### DIFF
--- a/source/postcard-derive/src/schema.rs
+++ b/source/postcard-derive/src/schema.rs
@@ -106,7 +106,7 @@ impl Generator {
             }
             Data::Union(_) => Err(syn::Error::new(
                 span,
-                "unions are not supported by `postcard::experimental::schema`",
+                "#[derive(Schema)] does not support unions",
             )),
         }
     }

--- a/source/postcard-derive/src/schema.rs
+++ b/source/postcard-derive/src/schema.rs
@@ -27,7 +27,7 @@ pub fn do_derive_schema(input: DeriveInput) -> syn::Result<TokenStream> {
     let postcard_schema = &generator.postcard_schema;
     let expanded = quote! {
         impl #impl_generics #postcard_schema::Schema for #name #ty_generics #where_clause {
-            const SCHEMA: &'static #postcard_schema::schema::NamedType = #ty;
+            const SCHEMA: &'static #postcard_schema::schema::DataModelType = #ty;
         }
     };
 
@@ -81,35 +81,34 @@ impl Generator {
         name: String,
     ) -> Result<TokenStream, syn::Error> {
         let postcard_schema = &self.postcard_schema;
-        let ty = match data {
-            Data::Struct(data) => self.generate_struct(&data.fields),
+        match data {
+            Data::Struct(data) => {
+                let data = self.generate_struct(&data.fields);
+                Ok(quote! {
+                    &#postcard_schema::schema::DataModelType::Struct{
+                        name: #name,
+                        data: #data,
+                    }
+                })
+            }
             Data::Enum(data) => {
-                let name = data.variants.iter().map(|v| v.ident.to_string());
-                let ty = data
-                    .variants
-                    .iter()
-                    .map(|v| self.generate_variants(&v.fields));
+                let variants = data.variants.iter().map(|v| {
+                    let (name, data) = (v.ident.to_string(), self.generate_variants(&v.fields));
+                    quote! { #postcard_schema::schema::Variant { name: #name, data: #data } }
+                });
 
-                quote! {
-                    &#postcard_schema::schema::DataModelType::Enum(&[
-                        #( &#postcard_schema::schema::NamedVariant { name: #name, ty: #ty } ),*
-                    ])
-                }
+                Ok(quote! {
+                    &#postcard_schema::schema::DataModelType::Enum {
+                        name: #name,
+                        variants: &[#(&#variants),*],
+                    }
+                })
             }
-            Data::Union(_) => {
-                return Err(syn::Error::new(
-                    span,
-                    "unions are not supported by `postcard::experimental::schema`",
-                ))
-            }
-        };
-
-        Ok(quote! {
-            &#postcard_schema::schema::NamedType {
-                name: #name,
-                ty: #ty,
-            }
-        })
+            Data::Union(_) => Err(syn::Error::new(
+                span,
+                "unions are not supported by `postcard::experimental::schema`",
+            )),
+        }
     }
 
     fn generate_struct(&self, fields: &Fields) -> TokenStream {
@@ -117,11 +116,11 @@ impl Generator {
         match fields {
             syn::Fields::Named(fields) => {
                 let fields = fields.named.iter().map(|f| {
-                let ty = &f.ty;
-                let name = f.ident.as_ref().unwrap().to_string();
-                quote_spanned!(f.span() => &#postcard_schema::schema::NamedValue { name: #name, ty: <#ty as #postcard_schema::Schema>::SCHEMA })
-            });
-                quote! { &#postcard_schema::schema::DataModelType::Struct(&[
+                    let ty = &f.ty;
+                    let name = f.ident.as_ref().unwrap().to_string();
+                    quote_spanned!(f.span() => &#postcard_schema::schema::NamedField { name: #name, ty: <#ty as #postcard_schema::Schema>::SCHEMA })
+                });
+                quote! { #postcard_schema::schema::Data::Struct(&[
                     #( #fields ),*
                 ]) }
             }
@@ -131,19 +130,19 @@ impl Generator {
                     let ty = &f.ty;
                     let qs = quote_spanned!(f.span() => <#ty as #postcard_schema::Schema>::SCHEMA);
 
-                    quote! { &#postcard_schema::schema::DataModelType::NewtypeStruct(#qs) }
+                    quote! { #postcard_schema::schema::Data::Newtype(#qs) }
                 } else {
                     let fields = fields.unnamed.iter().map(|f| {
                         let ty = &f.ty;
                         quote_spanned!(f.span() => <#ty as #postcard_schema::Schema>::SCHEMA)
                     });
-                    quote! { &#postcard_schema::schema::DataModelType::TupleStruct(&[
+                    quote! { #postcard_schema::schema::Data::Tuple(&[
                         #( #fields ),*
                     ]) }
                 }
             }
             syn::Fields::Unit => {
-                quote! { &#postcard_schema::schema::DataModelType::UnitStruct }
+                quote! { #postcard_schema::schema::Data::Unit }
             }
         }
     }
@@ -153,11 +152,11 @@ impl Generator {
         match fields {
             syn::Fields::Named(fields) => {
                 let fields = fields.named.iter().map(|f| {
-                let ty = &f.ty;
-                let name = f.ident.as_ref().unwrap().to_string();
-                quote_spanned!(f.span() => &#postcard_schema::schema::NamedValue { name: #name, ty: <#ty as #postcard_schema::Schema>::SCHEMA })
-            });
-                quote! { &#postcard_schema::schema::DataModelVariant::StructVariant(&[
+                    let ty = &f.ty;
+                    let name = f.ident.as_ref().unwrap().to_string();
+                    quote_spanned!(f.span() => &#postcard_schema::schema::NamedField { name: #name, ty: <#ty as #postcard_schema::Schema>::SCHEMA })
+                });
+                quote! { #postcard_schema::schema::Data::Struct(&[
                     #( #fields ),*
                 ]) }
             }
@@ -167,19 +166,19 @@ impl Generator {
                     let ty = &f.ty;
                     let qs = quote_spanned!(f.span() => <#ty as #postcard_schema::Schema>::SCHEMA);
 
-                    quote! { &#postcard_schema::schema::DataModelVariant::NewtypeVariant(#qs) }
+                    quote! { #postcard_schema::schema::Data::Newtype(#qs) }
                 } else {
                     let fields = fields.unnamed.iter().map(|f| {
                         let ty = &f.ty;
                         quote_spanned!(f.span() => <#ty as #postcard_schema::Schema>::SCHEMA)
                     });
-                    quote! { &#postcard_schema::schema::DataModelVariant::TupleVariant(&[
+                    quote! { #postcard_schema::schema::Data::Tuple(&[
                         #( #fields ),*
                     ]) }
                 }
             }
             syn::Fields::Unit => {
-                quote! { &#postcard_schema::schema::DataModelVariant::UnitVariant }
+                quote! { #postcard_schema::schema::Data::Unit }
             }
         }
     }

--- a/source/postcard-schema/src/impls/builtins_alloc.rs
+++ b/source/postcard-schema/src/impls/builtins_alloc.rs
@@ -1,39 +1,24 @@
 //! Implementations of the [`Schema`] trait for `alloc` types
 
-use crate::{
-    schema::{DataModelType, NamedType},
-    Schema,
-};
+use crate::{schema::DataModelType, Schema};
 
 extern crate alloc;
 
 impl<T: Schema> Schema for alloc::vec::Vec<T> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "Vec<T>",
-        ty: &DataModelType::Seq(T::SCHEMA),
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(T::SCHEMA);
 }
 
 impl Schema for alloc::string::String {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "String",
-        ty: &DataModelType::String,
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::String;
 }
 
 impl<K: Schema, V: Schema> Schema for alloc::collections::BTreeMap<K, V> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "BTreeMap<K, V>",
-        ty: &DataModelType::Map {
-            key: K::SCHEMA,
-            val: V::SCHEMA,
-        },
+    const SCHEMA: &'static DataModelType = &DataModelType::Map {
+        key: K::SCHEMA,
+        val: V::SCHEMA,
     };
 }
 
 impl<K: Schema> Schema for alloc::collections::BTreeSet<K> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "BTreeSet<K>",
-        ty: &DataModelType::Seq(K::SCHEMA),
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(K::SCHEMA);
 }

--- a/source/postcard-schema/src/impls/builtins_std.rs
+++ b/source/postcard-schema/src/impls/builtins_std.rs
@@ -1,68 +1,44 @@
 //! Implementations of the [`Schema`] trait for `std` types
 
-use crate::{
-    schema::{DataModelType, NamedType},
-    Schema,
-};
+use crate::{schema::DataModelType, Schema};
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: Schema> Schema for std::vec::Vec<T> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "Vec<T>",
-        ty: &DataModelType::Seq(T::SCHEMA),
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(T::SCHEMA);
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl Schema for std::string::String {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "String",
-        ty: &DataModelType::String,
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::String;
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "use-std")))]
 impl Schema for std::path::PathBuf {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "PathBuf",
-        ty: &DataModelType::String,
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::String;
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<K: Schema, V: Schema> Schema for std::collections::HashMap<K, V> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "HashMap<K, V>",
-        ty: &DataModelType::Map {
-            key: K::SCHEMA,
-            val: V::SCHEMA,
-        },
+    const SCHEMA: &'static DataModelType = &DataModelType::Map {
+        key: K::SCHEMA,
+        val: V::SCHEMA,
     };
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<K: Schema, V: Schema> Schema for std::collections::BTreeMap<K, V> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "BTreeMap<K, V>",
-        ty: &DataModelType::Map {
-            key: K::SCHEMA,
-            val: V::SCHEMA,
-        },
+    const SCHEMA: &'static DataModelType = &DataModelType::Map {
+        key: K::SCHEMA,
+        val: V::SCHEMA,
     };
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<K: Schema> Schema for std::collections::HashSet<K> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "HashSet<K>",
-        ty: &DataModelType::Seq(K::SCHEMA),
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(K::SCHEMA);
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<K: Schema> Schema for std::collections::BTreeSet<K> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "BTreeSet<K>",
-        ty: &DataModelType::Seq(K::SCHEMA),
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(K::SCHEMA);
 }

--- a/source/postcard-schema/src/impls/chrono_v0_4.rs
+++ b/source/postcard-schema/src/impls/chrono_v0_4.rs
@@ -1,11 +1,8 @@
 //! Implementations of the [`Schema`] trait for the `chrono` crate v0.4
 
-use crate::{schema::NamedType, Schema};
+use crate::{schema::DataModelType, Schema};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono-v0_4")))]
 impl<Tz: chrono_v0_4::TimeZone> Schema for chrono_v0_4::DateTime<Tz> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "DateTime",
-        ty: <&str>::SCHEMA.ty,
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::String;
 }

--- a/source/postcard-schema/src/impls/heapless_v0_7.rs
+++ b/source/postcard-schema/src/impls/heapless_v0_7.rs
@@ -1,21 +1,13 @@
 //! Implementations of the [`Schema`] trait for the `heapless` crate v0.7
 
-use crate::{
-    schema::{DataModelType, NamedType},
-    Schema,
-};
+use crate::{schema::DataModelType, Schema};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "heapless-v0_7")))]
 impl<T: Schema, const N: usize> Schema for heapless_v0_7::Vec<T, N> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "heapless::Vec<T, N>",
-        ty: &DataModelType::Seq(T::SCHEMA),
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(T::SCHEMA);
 }
+
 #[cfg_attr(docsrs, doc(cfg(feature = "heapless-v0_7")))]
 impl<const N: usize> Schema for heapless_v0_7::String<N> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "heapless::String<N>",
-        ty: &DataModelType::String,
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::String;
 }

--- a/source/postcard-schema/src/impls/heapless_v0_8.rs
+++ b/source/postcard-schema/src/impls/heapless_v0_8.rs
@@ -1,21 +1,13 @@
 //! Implementations of the [`Schema`] trait for the `heapless` crate v0.8
 
-use crate::{
-    schema::{DataModelType, NamedType},
-    Schema,
-};
+use crate::{schema::DataModelType, Schema};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "heapless-v0_8")))]
 impl<T: Schema, const N: usize> Schema for heapless_v0_8::Vec<T, N> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "heapless::Vec<T, N>",
-        ty: &DataModelType::Seq(T::SCHEMA),
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(T::SCHEMA);
 }
+
 #[cfg_attr(docsrs, doc(cfg(feature = "heapless-v0_8")))]
 impl<const N: usize> Schema for heapless_v0_8::String<N> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "heapless::String<N>",
-        ty: &DataModelType::String,
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::String;
 }

--- a/source/postcard-schema/src/impls/mod.rs
+++ b/source/postcard-schema/src/impls/mod.rs
@@ -2,10 +2,7 @@
 //!
 //! Each module requires the matching feature flag to be enabled.
 
-use crate::{
-    schema::{DataModelType, NamedType},
-    Schema,
-};
+use crate::{schema::DataModelType, Schema};
 
 pub mod builtins_nostd;
 
@@ -37,9 +34,6 @@ pub mod heapless_v0_8;
 #[cfg_attr(docsrs, doc(cfg(feature = "nalgebra-v0_33")))]
 pub mod nalgebra_v0_33;
 
-impl Schema for NamedType {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "NamedType",
-        ty: &DataModelType::Schema,
-    };
+impl Schema for DataModelType {
+    const SCHEMA: &'static DataModelType = &DataModelType::Schema;
 }

--- a/source/postcard-schema/src/impls/nalgebra_v0_33.rs
+++ b/source/postcard-schema/src/impls/nalgebra_v0_33.rs
@@ -1,9 +1,6 @@
 //! Implementations of the [`Schema`] trait for the `nalgebra` crate v0.33
 
-use crate::{
-    schema::{DataModelType, NamedType},
-    Schema,
-};
+use crate::{schema::DataModelType, Schema};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "nalgebra-v0_33")))]
 impl<T, const R: usize, const C: usize> Schema
@@ -16,10 +13,7 @@ impl<T, const R: usize, const C: usize> Schema
 where
     T: Schema + nalgebra_v0_33::Scalar,
 {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "nalgebra::Matrix<T, R, C, ArrayStorage<T, R, C>>",
-        ty: &DataModelType::Tuple(flatten(&[[T::SCHEMA; R]; C])),
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::Tuple(flatten(&[[T::SCHEMA; R]; C]));
 }
 
 /// Const version of the const-unstable [`<[[T; N]]>::as_flattened()`]
@@ -37,7 +31,7 @@ const fn flatten<T, const N: usize>(slice: &[[T; N]]) -> &[T] {
 #[test]
 fn flattened() {
     type T = nalgebra_v0_33::SMatrix<u8, 3, 3>;
-    assert_eq!(T::SCHEMA.ty, <[u8; 9]>::SCHEMA.ty);
+    assert_eq!(T::SCHEMA, <[u8; 9]>::SCHEMA);
 }
 
 #[test]

--- a/source/postcard-schema/src/impls/uuid_v1_0.rs
+++ b/source/postcard-schema/src/impls/uuid_v1_0.rs
@@ -1,13 +1,7 @@
 //! Implementations of the [`Schema`] trait for the `uuid` crate v1.0
 
-use crate::{
-    schema::{DataModelType, NamedType},
-    Schema,
-};
+use crate::{schema::DataModelType, Schema};
 
 impl Schema for uuid_v1_0::Uuid {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "Uuid",
-        ty: &DataModelType::ByteArray,
-    };
+    const SCHEMA: &'static DataModelType = &DataModelType::ByteArray;
 }

--- a/source/postcard-schema/src/key/hash.rs
+++ b/source/postcard-schema/src/key/hash.rs
@@ -408,7 +408,33 @@ pub mod fnv1a64_owned {
 
 #[cfg(test)]
 mod test {
+    use postcard_derive::Schema;
+
     use super::fnv1a64::hash_ty_path;
+
+    #[test]
+    fn hash_stability() {
+        #![allow(dead_code)]
+
+        #[derive(Schema)]
+        #[postcard(crate = crate)]
+        struct Foo {
+            a: u32,
+            b: String,
+        }
+
+        #[derive(Schema)]
+        #[postcard(crate = crate)]
+        enum Bar {
+            A,
+            B(Foo),
+        }
+
+        assert_eq!(
+            hash_ty_path::<Bar>("test_path"),
+            [139, 128, 52, 27, 107, 8, 218, 98]
+        );
+    }
 
     #[test]
     fn type_punning_good() {

--- a/source/postcard-schema/src/key/hash.rs
+++ b/source/postcard-schema/src/key/hash.rs
@@ -162,7 +162,7 @@ pub mod fnv1a64 {
                 }
                 state
             }
-            DataModelType::Schema => hash_update(state, &[0xB3]),
+            DataModelType::Schema => hash_update(state, &[0xE5]),
         }
     }
 
@@ -332,7 +332,7 @@ pub mod fnv1a64_owned {
                 }
                 state
             }
-            OwnedDataModelType::Schema => hash_update(state, &[0xB3]),
+            OwnedDataModelType::Schema => hash_update(state, &[0xE5]),
         }
     }
 

--- a/source/postcard-schema/src/key/mod.rs
+++ b/source/postcard-schema/src/key/mod.rs
@@ -11,10 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    schema::{DataModelType, NamedType},
-    Schema,
-};
+use crate::{schema::DataModelType, Schema};
 
 pub mod hash;
 
@@ -43,9 +40,9 @@ use defmt_v0_3 as defmt;
 pub struct Key([u8; 8]);
 
 impl Schema for Key {
-    const SCHEMA: &'static crate::schema::NamedType = &NamedType {
+    const SCHEMA: &'static crate::schema::DataModelType = &DataModelType::Struct {
         name: "Key",
-        ty: &DataModelType::NewtypeStruct(<[u8; 8] as Schema>::SCHEMA),
+        data: crate::schema::Data::Newtype(<[u8; 8] as Schema>::SCHEMA),
     };
 }
 
@@ -102,10 +99,10 @@ impl Key {
 #[cfg(feature = "use-std")]
 mod key_owned {
     use super::*;
-    use crate::schema::owned::OwnedNamedType;
+    use crate::schema::owned::OwnedDataModelType;
     impl Key {
-        /// Calculate the Key for the given path and [`OwnedNamedType`]
-        pub fn for_owned_schema_path(path: &str, nt: &OwnedNamedType) -> Key {
+        /// Calculate the Key for the given path and [`OwnedDataModelType`]
+        pub fn for_owned_schema_path(path: &str, nt: &OwnedDataModelType) -> Key {
             Key(hash::fnv1a64_owned::hash_ty_path_owned(path, nt))
         }
     }
@@ -113,53 +110,22 @@ mod key_owned {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        key::Key,
-        schema::{DataModelType, NamedType},
-        Schema,
-    };
+    use crate::{key::Key, schema::DataModelType, Schema};
 
     #[test]
     fn matches_old_postcard_rpc_defn() {
-        let old = &NamedType {
+        let old = &DataModelType::Struct {
             name: "Key",
-            ty: &DataModelType::NewtypeStruct(&NamedType {
-                name: "[T; N]",
-                ty: &DataModelType::Tuple(&[
-                    &NamedType {
-                        name: "u8",
-                        ty: &DataModelType::U8,
-                    },
-                    &NamedType {
-                        name: "u8",
-                        ty: &DataModelType::U8,
-                    },
-                    &NamedType {
-                        name: "u8",
-                        ty: &DataModelType::U8,
-                    },
-                    &NamedType {
-                        name: "u8",
-                        ty: &DataModelType::U8,
-                    },
-                    &NamedType {
-                        name: "u8",
-                        ty: &DataModelType::U8,
-                    },
-                    &NamedType {
-                        name: "u8",
-                        ty: &DataModelType::U8,
-                    },
-                    &NamedType {
-                        name: "u8",
-                        ty: &DataModelType::U8,
-                    },
-                    &NamedType {
-                        name: "u8",
-                        ty: &DataModelType::U8,
-                    },
-                ]),
-            }),
+            data: crate::schema::Data::Newtype(&DataModelType::Tuple(&[
+                &DataModelType::U8,
+                &DataModelType::U8,
+                &DataModelType::U8,
+                &DataModelType::U8,
+                &DataModelType::U8,
+                &DataModelType::U8,
+                &DataModelType::U8,
+                &DataModelType::U8,
+            ])),
         };
 
         let new = <Key as Schema>::SCHEMA;

--- a/source/postcard-schema/src/lib.rs
+++ b/source/postcard-schema/src/lib.rs
@@ -70,7 +70,7 @@ pub use postcard_derive::Schema;
 pub trait Schema {
     /// A recursive data structure that describes the schema of the given
     /// type.
-    const SCHEMA: &'static schema::NamedType;
+    const SCHEMA: &'static schema::DataModelType;
 }
 
 #[cfg(test)]
@@ -89,14 +89,14 @@ mod tests {
 
         assert_eq!(
             Point::SCHEMA,
-            &schema::NamedType {
+            &schema::DataModelType::Struct {
                 name: "Point",
-                ty: &schema::DataModelType::Struct(&[
-                    &schema::NamedValue {
+                data: schema::Data::Struct(&[
+                    &schema::NamedField {
                         name: "x",
                         ty: i32::SCHEMA
                     },
-                    &schema::NamedValue {
+                    &schema::NamedField {
                         name: "y",
                         ty: i32::SCHEMA
                     },

--- a/source/postcard-schema/src/schema/mod.rs
+++ b/source/postcard-schema/src/schema/mod.rs
@@ -3,7 +3,7 @@
 //! The types in this module are used to define the schema of a given data type.
 //!
 //! The **Postcard Data Model** is nearly identical to the **Serde Data Model**, however Postcard also
-//! allows for one additional type, `Schema`, which maps to the [`NamedValue`] type, allowing
+//! allows for one additional type, `Schema`, which maps to the [`DataModelType`] type, allowing
 //! the schema of types to also be sent over the wire and implement the `Schema` trait.
 //!
 //! ## Borrowed vs Owned
@@ -28,25 +28,11 @@ pub mod fmt;
 
 use serde::Serialize;
 
-/// A "NamedType" is used to describe the schema of a given type.
-///
-/// It contains two pieces of information:
-///
-/// * A `name`, which is the name of the type, e.g. "u8" for [`u8`].
-/// * A `ty`, which is one of the possible [`DataModelType`]s any given type can be represented as.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
-pub struct NamedType {
-    /// The name of this type
-    pub name: &'static str,
-    /// The type
-    pub ty: &'static DataModelType,
-}
-
 /// This enum lists which of the Data Model Types apply to a given type. This describes how the
 /// type is encoded on the wire.
 ///
-/// This enum contains all Serde Data Model types other than enum variants which exist in
-/// [`DataModelVariant`], as well as a "Schema" Model Type, which maps to [`NamedType`].
+/// This enum contains all Serde Data Model types as well as a "Schema" Type,
+/// which corresponds to [`DataModelType`] itself.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum DataModelType {
     /// The `bool` Serde Data Model Type
@@ -91,7 +77,7 @@ pub enum DataModelType {
     /// The `f32` Serde Data Model Type
     F32,
 
-    /// The `f64 Serde Data Model Type
+    /// The `f64` Serde Data Model Type
     F64,
 
     /// The `char` Serde Data Model Type
@@ -104,75 +90,78 @@ pub enum DataModelType {
     ByteArray,
 
     /// The `Option<T>` Serde Data Model Type
-    Option(&'static NamedType),
+    Option(&'static Self),
 
     /// The `()` Serde Data Model Type
     Unit,
 
-    /// The "unit struct" Serde Data Model Type
-    UnitStruct,
-
-    /// The "newtype struct" Serde Data Model Type
-    NewtypeStruct(&'static NamedType),
-
     /// The "Sequence" Serde Data Model Type
-    Seq(&'static NamedType),
+    Seq(&'static Self),
 
     /// The "Tuple" Serde Data Model Type
-    Tuple(&'static [&'static NamedType]),
-
-    /// The "Tuple Struct" Serde Data Model Type
-    TupleStruct(&'static [&'static NamedType]),
+    Tuple(&'static [&'static Self]),
 
     /// The "Map" Serde Data Model Type
     Map {
         /// The map "Key" type
-        key: &'static NamedType,
+        key: &'static Self,
         /// The map "Value" type
-        val: &'static NamedType,
+        val: &'static Self,
     },
 
-    /// The "Struct" Serde Data Model Type
-    Struct(&'static [&'static NamedValue]),
+    /// One of the struct Serde Data Model types
+    Struct {
+        /// The name of this struct
+        name: &'static str,
+        /// The data contained in this struct
+        data: Data,
+    },
 
     /// The "Enum" Serde Data Model Type (which contains any of the "Variant" types)
-    Enum(&'static [&'static NamedVariant]),
+    Enum {
+        /// The name of this struct
+        name: &'static str,
+        /// The variants contained in this enum
+        variants: &'static [&'static Variant],
+    },
 
-    /// A NamedType/OwnedNamedType
+    /// A [`DataModelType`]/[`OwnedDataModelType`](owned::OwnedDataModelType)
     Schema,
 }
 
-/// This is similar to [`DataModelType`], however it only contains the potential Data Model Types
-/// used as variants of an `enum`.
+/// The contents of a struct or enum variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
-pub enum DataModelVariant {
-    /// The "unit variant" Serde Data Model Type
-    UnitVariant,
-    /// The "newtype variant" Serde Data Model Type
-    NewtypeVariant(&'static NamedType),
-    /// The "Tuple Variant" Serde Data Model Type
-    TupleVariant(&'static [&'static NamedType]),
-    /// The "Struct Variant" Serde Data Model Type
-    StructVariant(&'static [&'static NamedValue]),
+pub enum Data {
+    /// The "Unit Struct" or "Unit Variant" Serde Data Model Type
+    Unit,
+
+    /// The "Newtype Struct" or "Newtype Variant" Serde Data Model Type
+    Newtype(&'static DataModelType),
+
+    /// The "Tuple Struct" or "Tuple Variant" Serde Data Model Type
+    Tuple(&'static [&'static DataModelType]),
+
+    /// The "Struct" or "Struct Variant" Serde Data Model Type
+    Struct(&'static [&'static NamedField]),
 }
 
 /// This represents a named struct field.
 ///
 /// For example, in `struct Ex { a: u32 }` the field `a` would be reflected as
-/// `NamedValue { name: "a", ty: DataModelType::U32 }`.
+/// `NamedField { name: "a", ty: DataModelType::U32 }`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
-pub struct NamedValue {
-    /// The name of this value
+pub struct NamedField {
+    /// The name of this field
     pub name: &'static str,
-    /// The type of this value
-    pub ty: &'static NamedType,
+    /// The type of this field
+    pub ty: &'static DataModelType,
 }
 
-/// An enum variant with a name, e.g. `T::Bar(...)`
+/// An enum variant e.g. `T::Bar(...)`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
-pub struct NamedVariant {
+pub struct Variant {
     /// The name of this variant
     pub name: &'static str,
-    /// The type of this variant
-    pub ty: &'static DataModelVariant,
+    /// The data contained in this variant
+    pub data: Data,
 }

--- a/source/postcard-schema/tests/schema.rs
+++ b/source/postcard-schema/tests/schema.rs
@@ -1,32 +1,8 @@
 use postcard_schema::{
-    schema::{
-        owned::OwnedNamedType, DataModelType, DataModelVariant, NamedType, NamedValue, NamedVariant,
-    },
+    schema::{owned::OwnedDataModelType, Data, DataModelType, NamedField, Variant},
     Schema,
 };
 use std::path::PathBuf;
-
-const U8_SCHEMA: NamedType = NamedType {
-    name: "u8",
-    ty: &DataModelType::U8,
-};
-const U32_SCHEMA: NamedType = NamedType {
-    name: "u32",
-    ty: &DataModelType::U32,
-};
-const U64_SCHEMA: NamedType = NamedType {
-    name: "u64",
-    ty: &DataModelType::U64,
-};
-
-const I16_SCHEMA: NamedType = NamedType {
-    name: "i16",
-    ty: &DataModelType::I16,
-};
-const I32_SCHEMA: NamedType = NamedType {
-    name: "i32",
-    ty: &DataModelType::I32,
-};
 
 #[allow(unused)]
 #[derive(Schema)]
@@ -78,45 +54,39 @@ mod bound {
 #[test]
 fn test_enum_serialize() {
     assert_eq!(
-        &NamedType {
+        &DataModelType::Enum {
             name: "Inner",
-            ty: &DataModelType::Enum(&[
-                &NamedVariant {
+            variants: &[
+                &Variant {
                     name: "Alpha",
-                    ty: &DataModelVariant::UnitVariant
+                    data: Data::Unit
                 },
-                &NamedVariant {
+                &Variant {
                     name: "Beta",
-                    ty: &DataModelVariant::UnitVariant
+                    data: Data::Unit
                 },
-                &NamedVariant {
+                &Variant {
                     name: "Gamma",
-                    ty: &DataModelVariant::UnitVariant
+                    data: Data::Unit
                 },
-                &NamedVariant {
+                &Variant {
                     name: "Delta",
-                    ty: &DataModelVariant::TupleVariant(&[&I32_SCHEMA, &I16_SCHEMA,])
+                    data: Data::Tuple(&[i32::SCHEMA, i16::SCHEMA,])
                 },
-                &NamedVariant {
+                &Variant {
                     name: "Epsilon",
-                    ty: &DataModelVariant::StructVariant(&[
-                        &NamedValue {
+                    data: Data::Struct(&[
+                        &NamedField {
                             name: "zeta",
-                            ty: &NamedType {
-                                name: "f32",
-                                ty: &DataModelType::F32
-                            },
+                            ty: f32::SCHEMA,
                         },
-                        &NamedValue {
+                        &NamedField {
                             name: "eta",
-                            ty: &NamedType {
-                                name: "bool",
-                                ty: &DataModelType::Bool
-                            },
+                            ty: bool::SCHEMA,
                         }
                     ]),
                 }
-            ]),
+            ],
         },
         Inner::SCHEMA
     );
@@ -124,45 +94,34 @@ fn test_enum_serialize() {
 
 #[test]
 fn test_struct_serialize() {
-    const TEN_BYTES_SCHEMA: &[&NamedType] = &[&U8_SCHEMA; 10];
-
     assert_eq!(
         Outer::SCHEMA,
-        &NamedType {
+        &DataModelType::Struct {
             name: "Outer",
-            ty: &DataModelType::Struct(&[
-                &NamedValue {
+            data: Data::Struct(&[
+                &NamedField {
                     name: "a",
-                    ty: &U32_SCHEMA
+                    ty: u32::SCHEMA
                 },
-                &NamedValue {
+                &NamedField {
                     name: "b",
-                    ty: &U64_SCHEMA
+                    ty: u64::SCHEMA
                 },
-                &NamedValue {
+                &NamedField {
                     name: "c",
-                    ty: &U8_SCHEMA
+                    ty: u8::SCHEMA
                 },
-                &NamedValue {
+                &NamedField {
                     name: "d",
                     ty: Inner::SCHEMA
                 },
-                &NamedValue {
+                &NamedField {
                     name: "e",
-                    ty: &NamedType {
-                        name: "[T; N]",
-                        ty: &DataModelType::Tuple(TEN_BYTES_SCHEMA),
-                    }
+                    ty: &DataModelType::Tuple(&[u8::SCHEMA; 10]),
                 },
-                &NamedValue {
+                &NamedField {
                     name: "f",
-                    ty: &NamedType {
-                        name: "[T]",
-                        ty: &DataModelType::Seq(&NamedType {
-                            name: "u8",
-                            ty: &DataModelType::U8
-                        })
-                    }
+                    ty: &DataModelType::Seq(u8::SCHEMA),
                 },
             ]),
         }
@@ -172,15 +131,12 @@ fn test_struct_serialize() {
 #[test]
 fn test_slice_serialize() {
     assert_eq!(
-        &NamedType {
+        &DataModelType::Struct {
             name: "Slice",
-            ty: &DataModelType::Struct(&[&NamedValue {
+            data: Data::Struct(&[&NamedField {
                 name: "x",
-                ty: &NamedType {
-                    name: "[T]",
-                    ty: &DataModelType::Seq(&U8_SCHEMA)
-                }
-            },]),
+                ty: &DataModelType::Seq(u8::SCHEMA),
+            }]),
         },
         Slice::SCHEMA
     );
@@ -189,11 +145,11 @@ fn test_slice_serialize() {
 #[test]
 fn test_bound_serialize() {
     assert_eq!(
-        &NamedType {
+        &DataModelType::Struct {
             name: "Bound",
-            ty: &DataModelType::Struct(&[&NamedValue {
+            data: Data::Struct(&[&NamedField {
                 name: "x",
-                ty: &U8_SCHEMA
+                ty: u8::SCHEMA
             }]),
         },
         Bound::<bound::Id>::SCHEMA,
@@ -230,7 +186,7 @@ struct TestStruct2<'a> {
 #[test]
 fn owned_punning() {
     let borrowed_schema = TestStruct2::SCHEMA;
-    let owned_schema: OwnedNamedType = borrowed_schema.into();
+    let owned_schema: OwnedDataModelType = borrowed_schema.into();
 
     // Check that they are the same on the wire when serialized
     let ser_borrowed_schema = postcard::to_stdvec(borrowed_schema).unwrap();
@@ -239,12 +195,12 @@ fn owned_punning() {
 
     // TODO: This is wildly repetitive, and likely could benefit from interning of
     // repeated types, strings, etc.
-    assert_eq!(ser_borrowed_schema.len(), 268);
+    assert_eq!(ser_borrowed_schema.len(), 187);
 
     // Check that we round-trip correctly
     let deser_borrowed_schema =
-        postcard::from_bytes::<OwnedNamedType>(&ser_borrowed_schema).unwrap();
-    let deser_owned_schema = postcard::from_bytes::<OwnedNamedType>(&ser_owned_schema).unwrap();
+        postcard::from_bytes::<OwnedDataModelType>(&ser_borrowed_schema).unwrap();
+    let deser_owned_schema = postcard::from_bytes::<OwnedDataModelType>(&ser_owned_schema).unwrap();
     assert_eq!(deser_borrowed_schema, deser_owned_schema);
     assert_eq!(deser_borrowed_schema, owned_schema);
     assert_eq!(deser_owned_schema, owned_schema);
@@ -269,34 +225,34 @@ enum TestEnum2 {
 fn newtype_vs_tuple() {
     assert_eq!(
         TestStruct3::SCHEMA,
-        &NamedType {
+        &DataModelType::Struct {
             name: "TestStruct3",
-            ty: &DataModelType::NewtypeStruct(u64::SCHEMA)
+            data: Data::Newtype(u64::SCHEMA)
         }
     );
 
     assert_eq!(
         TestStruct4::SCHEMA,
-        &NamedType {
+        &DataModelType::Struct {
             name: "TestStruct4",
-            ty: &DataModelType::TupleStruct(&[u64::SCHEMA, bool::SCHEMA]),
+            data: Data::Tuple(&[u64::SCHEMA, bool::SCHEMA]),
         }
     );
 
     assert_eq!(
         TestEnum2::SCHEMA,
-        &NamedType {
+        &DataModelType::Enum {
             name: "TestEnum2",
-            ty: &DataModelType::Enum(&[
-                &NamedVariant {
+            variants: &[
+                &Variant {
                     name: "Nt",
-                    ty: &DataModelVariant::NewtypeVariant(u64::SCHEMA)
+                    data: Data::Newtype(u64::SCHEMA)
                 },
-                &NamedVariant {
+                &Variant {
                     name: "Tup",
-                    ty: &DataModelVariant::TupleVariant(&[u64::SCHEMA, bool::SCHEMA])
+                    data: Data::Tuple(&[u64::SCHEMA, bool::SCHEMA])
                 },
-            ]),
+            ],
         }
     );
 }
@@ -304,7 +260,7 @@ fn newtype_vs_tuple() {
 // Formatting
 
 fn dewit<T: Schema>() -> String {
-    let schema: OwnedNamedType = T::SCHEMA.into();
+    let schema: OwnedDataModelType = T::SCHEMA.into();
     schema.to_pseudocode()
 }
 


### PR DESCRIPTION
Closes #196

This keeps the hashing behavior of ignoring struct/variant names, but these could be taken into account without sacrificing punning of vecs/slices/other seqs.