### PR TITLE
allow to_extend to work with reference to write

### DIFF
--- a/source/postcard/src/lib.rs
+++ b/source/postcard/src/lib.rs
@@ -65,7 +65,10 @@ pub use de::flavors as de_flavors;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
 pub use ser::flavors as ser_flavors;
-pub use ser::{serialize_with_flavor, serializer::Serializer, to_extend, to_slice, to_slice_cobs};
+pub use ser::{
+    serialize_with_flavor, serializer::Serializer, to_extend, to_extend_ref, to_slice,
+    to_slice_cobs,
+};
 
 #[cfg(feature = "heapless")]
 pub use ser::{to_vec, to_vec_cobs};

--- a/source/postcard/src/ser/flavors.rs
+++ b/source/postcard/src/ser/flavors.rs
@@ -250,6 +250,47 @@ where
     }
 }
 
+/// Wrapper over a [`core::iter::Extend<u8>`] that implements the flavor trait
+///
+/// This is like [`ExtendFlavor`], but it takes the writer by reference instead of
+/// by value. This allows you to remain in control of the writer.
+pub struct ExtendRefFlavor<'a, T> {
+    iter: &'a mut T,
+}
+
+impl<'a, T> ExtendRefFlavor<'a, T>
+where
+    T: core::iter::Extend<u8>,
+{
+    /// Create a new [`Self`] flavor from a given [`core::iter::Extend<u8>`]
+    pub fn new(iter: &'a mut T) -> Self {
+        Self { iter }
+    }
+}
+
+impl<T> Flavor for ExtendRefFlavor<'_, T>
+where
+    T: core::iter::Extend<u8>,
+{
+    type Output = ();
+
+    #[inline(always)]
+    fn try_push(&mut self, data: u8) -> Result<()> {
+        self.iter.extend([data]);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn try_extend(&mut self, b: &[u8]) -> Result<()> {
+        self.iter.extend(b.iter().copied());
+        Ok(())
+    }
+
+    fn finalize(self) -> Result<Self::Output> {
+        Ok(())
+    }
+}
+
 /// Support for the [`embedded-io`](crate::eio::embedded_io) traits
 #[cfg(any(feature = "embedded-io-04", feature = "embedded-io-06"))]
 pub mod eio {

--- a/source/postcard/src/ser/mod.rs
+++ b/source/postcard/src/ser/mod.rs
@@ -274,6 +274,29 @@ where
     serialize_with_flavor::<T, _, _>(value, flavors::ExtendFlavor::new(writer))
 }
 
+/// Serialize a `T` to a [`core::iter::Extend`],
+///
+/// This is like [`to_extend`], but it takes the writer by reference instead of
+/// by value. This allows you to remain in control of the writer.
+///
+/// ## Example
+///
+/// ```rust
+/// use postcard::to_extend_ref;
+/// let mut vec = Vec::new();
+///
+/// to_extend_ref(&true, &mut vec).unwrap();
+/// to_extend_ref("Hi!", &mut vec).unwrap();
+/// assert_eq!(&vec[0..5], &[0x01, 0x03, b'H', b'i', b'!']);
+/// ```
+pub fn to_extend_ref<T, W>(value: &T, writer: &mut W) -> Result<()>
+where
+    T: Serialize + ?Sized,
+    W: core::iter::Extend<u8>,
+{
+    serialize_with_flavor::<T, _, _>(value, flavors::ExtendRefFlavor::new(writer))
+}
+
 /// Serialize a `T` to an [`embedded_io Write`](crate::eio::Write),
 /// ## Example
 ///


### PR DESCRIPTION
Currently the function takes the collection by value. Taking by mutable reference is better because it is more flexible. Whenever you have a value, you can also pass by mutable reference, but sometimes you only have a mutable reference and cannot pass by value.

This also fixes another problem with the current API: It keeps the collection on error. On success it returns it to the caller, but on error it does not. This makes the caller lose the collection.

I implement this as a new function rather than by changing the existing to_extend so that this is not a breaking change. When postcard is willing to make breaking changes in the future, then it could decide to remove the existing to_extend.

This is an alternative to #208 .