### PR TITLE
Support `std::io::Read` flavor with minimal temporary buffer

### DIFF
--- a/source/postcard/src/de/deserializer.rs
+++ b/source/postcard/src/de/deserializer.rs
@@ -326,9 +326,7 @@ impl<'de, F: Flavor<'de>> de::Deserializer<'de> for &mut Deserializer<'de, F> {
     where
         V: Visitor<'de>,
     {
-        let bytes = self.flavor.try_take_n(4)?;
-        let mut buf = [0u8; 4];
-        buf.copy_from_slice(bytes);
+        let buf = self.flavor.try_take_n_const::<4>()?;
         visitor.visit_f32(f32::from_bits(u32::from_le_bytes(buf)))
     }
 
@@ -337,9 +335,7 @@ impl<'de, F: Flavor<'de>> de::Deserializer<'de> for &mut Deserializer<'de, F> {
     where
         V: Visitor<'de>,
     {
-        let bytes = self.flavor.try_take_n(8)?;
-        let mut buf = [0u8; 8];
-        buf.copy_from_slice(bytes);
+        let buf = self.flavor.try_take_n_const::<8>()?;
         visitor.visit_f64(f64::from_bits(u64::from_le_bytes(buf)))
     }
 
@@ -352,7 +348,7 @@ impl<'de, F: Flavor<'de>> de::Deserializer<'de> for &mut Deserializer<'de, F> {
         if sz > 4 {
             return Err(Error::DeserializeBadChar);
         }
-        let bytes: &'de [u8] = self.flavor.try_take_n(sz)?;
+        let bytes: &[u8] = self.flavor.try_take_n_temp(sz)?;
         // we pass the character through string conversion because
         // this handles transforming the array of code units to a
         // codepoint. we can't use char::from_u32() because it expects
@@ -371,7 +367,7 @@ impl<'de, F: Flavor<'de>> de::Deserializer<'de> for &mut Deserializer<'de, F> {
         V: Visitor<'de>,
     {
         let sz = self.try_take_varint_usize()?;
-        let bytes: &'de [u8] = self.flavor.try_take_n(sz)?;
+        let bytes: &'de [u8] = self.flavor.try_take_n_borrowed(sz)?;
         let str_sl = core::str::from_utf8(bytes).map_err(|_| Error::DeserializeBadUtf8)?;
 
         visitor.visit_borrowed_str(str_sl)
@@ -382,7 +378,11 @@ impl<'de, F: Flavor<'de>> de::Deserializer<'de> for &mut Deserializer<'de, F> {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_str(visitor)
+        let sz = self.try_take_varint_usize()?;
+        let bytes: &[u8] = self.flavor.try_take_n_temp(sz)?;
+        let str_sl = core::str::from_utf8(bytes).map_err(|_| Error::DeserializeBadUtf8)?;
+
+        visitor.visit_str(str_sl)
     }
 
     #[inline]
@@ -391,7 +391,7 @@ impl<'de, F: Flavor<'de>> de::Deserializer<'de> for &mut Deserializer<'de, F> {
         V: Visitor<'de>,
     {
         let sz = self.try_take_varint_usize()?;
-        let bytes: &'de [u8] = self.flavor.try_take_n(sz)?;
+        let bytes: &'de [u8] = self.flavor.try_take_n_borrowed(sz)?;
         visitor.visit_borrowed_bytes(bytes)
     }
 
@@ -400,7 +400,9 @@ impl<'de, F: Flavor<'de>> de::Deserializer<'de> for &mut Deserializer<'de, F> {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_bytes(visitor)
+        let sz = self.try_take_varint_usize()?;
+        let bytes: &[u8] = self.flavor.try_take_n_temp(sz)?;
+        visitor.visit_bytes(bytes)
     }
 
     #[inline]

--- a/source/postcard/src/de/flavors.rs
+++ b/source/postcard/src/de/flavors.rs
@@ -116,8 +116,37 @@ pub trait Flavor<'de>: 'de {
         None
     }
 
-    /// Attempt to take the next `ct` bytes from the serialized message
-    fn try_take_n(&mut self, ct: usize) -> Result<&'de [u8]>;
+    /// Attempt to take the next `ct` bytes from the serialized message.
+    ///
+    /// This variant borrows the data from the input for zero-copy deserialization. If zero-copy
+    /// deserialization is not necessary, prefer to use `try_take_n_temp` instead.
+    fn try_take_n_borrowed(&mut self, ct: usize) -> Result<&'de [u8]>;
+
+    /// Attempt to take the next `N` bytes from the serialized message.
+    ///
+    /// This variant copies the data into a fixed-size buffer.
+    fn try_take_n_const<const N: usize>(&mut self) -> Result<[u8; N]> {
+        Ok(self.try_take_n_borrowed(N)?.try_into().unwrap())
+    }
+
+    /// Attempt to take the next `ct` bytes from the serialized message.
+    ///
+    /// This variant does not guarantee that the returned value is borrowed from the input, so it
+    /// cannot be used for zero-copy deserialization, but it also avoids needing to potentially
+    /// allocate a data in a temporary buffer.
+    ///
+    /// This variant should be used instead of `try_take_n`
+    /// if zero-copy deserialization is not necessary.
+    ///
+    /// It is only necessary to implement this method if the flavor requires storing data in a
+    /// temporary buffer in order to implement the borrow semantics, e.g. the `std::io::Read`
+    /// flavor.
+    fn try_take_n_temp<'a>(&'a mut self, ct: usize) -> Result<&'a [u8]>
+    where
+        'de: 'a,
+    {
+        self.try_take_n_borrowed(ct)
+    }
 
     /// Complete the deserialization process.
     ///
@@ -169,7 +198,7 @@ impl<'de> Flavor<'de> for Slice<'de> {
     }
 
     #[inline]
-    fn try_take_n(&mut self, ct: usize) -> Result<&'de [u8]> {
+    fn try_take_n_borrowed(&mut self, ct: usize) -> Result<&'de [u8]> {
         let remain = (self.end as usize) - (self.cursor as usize);
         if remain < ct {
             Err(Error::DeserializeUnexpectedEnd)
@@ -215,11 +244,6 @@ pub mod io {
         }
 
         #[inline]
-        fn size(&self) -> usize {
-            (self.end as usize) - (self.cursor as usize)
-        }
-
-        #[inline]
         fn take_n(&mut self, ct: usize) -> Result<&'de mut [u8]> {
             let remain = (self.end as usize) - (self.cursor as usize);
             let buff = if remain < ct {
@@ -228,6 +252,21 @@ pub mod io {
                 unsafe {
                     let sli = core::slice::from_raw_parts_mut(self.cursor, ct);
                     self.cursor = self.cursor.add(ct);
+                    sli
+                }
+            };
+
+            Ok(buff)
+        }
+
+        #[inline]
+        fn take_n_temp(&mut self, ct: usize) -> Result<&mut [u8]> {
+            let remain = (self.end as usize) - (self.cursor as usize);
+            let buff = if remain < ct {
+                return Err(Error::DeserializeUnexpectedEnd);
+            } else {
+                unsafe {
+                    let sli = core::slice::from_raw_parts_mut(self.cursor, ct);
                     sli
                 }
             };
@@ -290,12 +329,33 @@ pub mod io {
 
             #[inline]
             fn size_hint(&self) -> Option<usize> {
-                Some(self.buff.size())
+                None
             }
 
             #[inline]
-            fn try_take_n(&mut self, ct: usize) -> Result<&'de [u8]> {
+            fn try_take_n_borrowed(&mut self, ct: usize) -> Result<&'de [u8]> {
                 let buff = self.buff.take_n(ct)?;
+                self.reader
+                    .read_exact(buff)
+                    .map_err(|_| Error::DeserializeUnexpectedEnd)?;
+                Ok(buff)
+            }
+
+            #[inline]
+            fn try_take_n_const<const N: usize>(&mut self) -> Result<[u8; N]> {
+                let mut buff = [0; N];
+                self.reader
+                    .read_exact(&mut buff)
+                    .map_err(|_| Error::DeserializeUnexpectedEnd)?;
+                Ok(buff)
+            }
+
+            #[inline]
+            fn try_take_n_temp<'a>(&'a mut self, ct: usize) -> Result<&'a [u8]>
+            where
+                'de: 'a,
+            {
+                let buff = self.buff.take_n_temp(ct)?;
                 self.reader
                     .read_exact(buff)
                     .map_err(|_| Error::DeserializeUnexpectedEnd)?;
@@ -385,12 +445,33 @@ pub mod io {
 
             #[inline]
             fn size_hint(&self) -> Option<usize> {
-                Some(self.buff.size())
+                None
             }
 
             #[inline]
-            fn try_take_n(&mut self, ct: usize) -> Result<&'de [u8]> {
+            fn try_take_n_borrowed(&mut self, ct: usize) -> Result<&'de [u8]> {
                 let buff = self.buff.take_n(ct)?;
+                self.reader
+                    .read_exact(buff)
+                    .map_err(|_| Error::DeserializeUnexpectedEnd)?;
+                Ok(buff)
+            }
+
+            #[inline]
+            fn try_take_n_const<const N: usize>(&mut self) -> Result<[u8; N]> {
+                let mut buff = [0; N];
+                self.reader
+                    .read_exact(&mut buff)
+                    .map_err(|_| Error::DeserializeUnexpectedEnd)?;
+                Ok(buff)
+            }
+
+            #[inline]
+            fn try_take_n_temp<'a>(&'a mut self, ct: usize) -> Result<&'a [u8]>
+            where
+                'de: 'a,
+            {
+                let buff = self.buff.take_n_temp(ct)?;
                 self.reader
                     .read_exact(buff)
                     .map_err(|_| Error::DeserializeUnexpectedEnd)?;
@@ -510,8 +591,8 @@ pub mod crc {
                         }
 
                         #[inline]
-                        fn try_take_n(&mut self, ct: usize) -> Result<&'de [u8]> {
-                            match self.flav.try_take_n(ct) {
+                        fn try_take_n_borrowed(&mut self, ct: usize) -> Result<&'de [u8]> {
+                            match self.flav.try_take_n_borrowed(ct) {
                                 Ok(bytes) => {
                                     self.digest.update(bytes);
                                     Ok(bytes)
@@ -521,7 +602,7 @@ pub mod crc {
                         }
 
                         fn finalize(mut self) -> Result<Self::Remainder> {
-                            match self.flav.try_take_n(core::mem::size_of::<$int>()) {
+                            match self.flav.try_take_n_borrowed(core::mem::size_of::<$int>()) {
                                 Ok(prev_crc_bytes) => match self.flav.finalize() {
                                     Ok(remainder) => {
                                         let crc = self.digest.finalize();


### PR DESCRIPTION
As discussed in https://github.com/jamesmunns/postcard/issues/140, currently using the `from_io` or `from_eio` deserialization flavors require passing in a buffer which is large enough to hold almost all of the data, even if the type we are deserializing into is fully owned. This PR implements an approach where the buffer only needs to be large enough to hold the borrowed parts of the resulting type, plus the largest individual piece of data in the input (i.e. the longest string or byte sequence).

The current implementation requires storing more data than is necessary in the buffer because it uses the same implementation for borrowed and owned data. For example: https://github.com/jamesmunns/postcard/blob/9f8bbce2792043fdae1b9823d77377defcb39df9/source/postcard/src/de/deserializer.rs#L385

The borrowed version (`deserialize_str`) needs to return a slice bound by `'de`, so it takes space from the buffer. The owned version (`deserialize_string`) doesn't need `'de`, but it still takes space from the buffer anyway.

In this PR I split `Flavor::try_take_n` into three variants: one which borrows from the input data, one which returns a buffer of a const size, and one which returns a "temporary" slice which is borrowed from the input data but has a lifetime tied to the flavor itself, which in practice means only one temporary slice can be borrowed at a time.

I implemented these extra versions of `try_take_n` for the `from_io` and `from_eio` flavors and then switched to using the new versions in the deserializer implementation where possible.