### PR TITLE
Add Serialize and Deserialize traits to postcard::Error

### DIFF
--- a/source/postcard/src/error.rs
+++ b/source/postcard/src/error.rs
@@ -1,7 +1,8 @@
 use core::fmt::{Display, Formatter};
+use serde::{Serialize, Deserialize};
 
 /// This is the error type used by Postcard
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "use-defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {


### PR DESCRIPTION
This pull request addresses #214. As far as I can tell was a one-line change since both traits were already available, but if there's any issues, just let me know :)