### PR TITLE
Migrate from paste to with_builtin_macros

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -61,8 +61,8 @@ optional = true
 version = "3.0.1"
 optional = true
 
-[dependencies.paste]
-version = "1.0.12"
+[dependencies.with_builtin_macros]
+version = "0.1.0"
 optional = true
 
 [features]
@@ -80,7 +80,7 @@ use-std = ["serde/std", "alloc"]
 heapless-cas = ["heapless", "dep:heapless", "heapless/cas"]
 alloc = ["serde/alloc", "embedded-io-04?/alloc", "embedded-io-06?/alloc"]
 use-defmt = ["defmt"]
-use-crc = ["crc", "paste"]
+use-crc = ["crc", "with_builtin_macros"]
 
 # Experimental features!
 #
@@ -89,5 +89,5 @@ experimental-derive = ["postcard-derive"]
 crc = ["dep:crc"]
 defmt = ["dep:defmt"]
 heapless = ["dep:heapless"]
-paste = ["dep:paste"]
+with_builtin_macros = ["dep:with_builtin_macros"]
 postcard-derive = ["dep:postcard-derive"]

--- a/source/postcard/src/de/flavors.rs
+++ b/source/postcard/src/de/flavors.rs
@@ -458,7 +458,7 @@ pub mod crc {
     use crate::Deserializer;
     use crate::Error;
     use crate::Result;
-    use paste::paste;
+    use with_builtin_macros::with_eager_expansions;
 
     /// Manages CRC modifications as a flavor.
     pub struct CrcModifier<'de, B, W>
@@ -484,7 +484,7 @@ pub mod crc {
     macro_rules! impl_flavor {
         ($( $int:ty ),*) => {
             $(
-                paste! {
+                with_eager_expansions! {
                     impl<'de, B> Flavor<'de> for CrcModifier<'de, B, $int>
                     where
                         B: Flavor<'de>,
@@ -544,7 +544,7 @@ pub mod crc {
 
                     /// Deserialize a message of type `T` from a byte slice with a Crc. The unused portion (if any)
                     /// of the byte slice is not returned.
-                    pub fn [<from_bytes_ $int>]<'a, T>(s: &'a [u8], digest: Digest<'a, $int>) -> Result<T>
+                    pub fn #{concat_idents!(from_bytes_, $int)}<'a, T>(s: &'a [u8], digest: Digest<'a, $int>) -> Result<T>
                     where
                         T: Deserialize<'a>,
                     {
@@ -557,7 +557,7 @@ pub mod crc {
 
                     /// Deserialize a message of type `T` from a byte slice with a Crc. The unused portion (if any)
                     /// of the byte slice is returned for further usage
-                    pub fn [<take_from_bytes_ $int>]<'a, T>(s: &'a [u8], digest: Digest<'a, $int>) -> Result<(T, &'a [u8])>
+                    pub fn #{concat_idents!(take_from_bytes_, $int)}<'a, T>(s: &'a [u8], digest: Digest<'a, $int>) -> Result<(T, &'a [u8])>
                     where
                         T: Deserialize<'a>,
                     {

--- a/source/postcard/src/ser/flavors.rs
+++ b/source/postcard/src/ser/flavors.rs
@@ -585,7 +585,7 @@ pub mod crc {
 
     use crate::serialize_with_flavor;
     use crate::Result;
-    use paste::paste;
+    use with_builtin_macros::with_eager_expansions;
 
     /// Manages CRC modifications as a flavor.
     pub struct CrcModifier<'a, B, W>
@@ -611,7 +611,7 @@ pub mod crc {
     macro_rules! impl_flavor {
         ($( $int:ty ),*) => {
             $(
-                paste! {
+                with_eager_expansions! {
                     impl<'a, B> Flavor for CrcModifier<'a, B, $int>
                     where
                         B: Flavor,
@@ -638,7 +638,7 @@ pub mod crc {
                     ///
                     /// When successful, this function returns the slice containing the
                     /// serialized and encoded message.
-                    pub fn [<to_slice_ $int>]<'a, T>(
+                    pub fn #{concat_idents!(to_slice_, $int)}<'a, T>(
                         value: &T,
                         buf: &'a mut [u8],
                         digest: Digest<'_, $int>,
@@ -653,7 +653,7 @@ pub mod crc {
                     /// data followed by a CRC. The CRC bytes are included in the output `Vec`.
                     #[cfg(feature = "heapless")]
                     #[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
-                    pub fn [<to_vec_ $int>]<T, const B: usize>(
+                    pub fn #{concat_idents!(to_vec_, $int)}<T, const B: usize>(
                         value: &T,
                         digest: Digest<'_, $int>,
                     ) -> Result<heapless::Vec<u8, B>>
@@ -669,7 +669,7 @@ pub mod crc {
                     /// data followed by a CRC. The CRC bytes are included in the output `Vec`.
                     #[cfg(feature = "alloc")]
                     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-                    pub fn [<to_allocvec_ $int>]<T>(value: &T, digest: Digest<'_, $int>) -> Result<alloc::vec::Vec<u8>>
+                    pub fn #{concat_idents!(to_allocvec_, $int)}<T>(value: &T, digest: Digest<'_, $int>) -> Result<alloc::vec::Vec<u8>>
                     where
                         T: Serialize + ?Sized,
                     {


### PR DESCRIPTION
This is to deal with security warnings related to paste now being "unmaintained". These warnings affect everyone using automated security scanners and the "crc" feature.

Please see https://rustsec.org/advisories/RUSTSEC-2024-0436.html, https://github.com/rustsec/advisory-db/issues/2203 and https://github.com/rustsec/advisory-db/pull/2215 for more details.