### PR TITLE
Update cobs to 0.3.0

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -36,7 +36,7 @@ default-features = false
 features = ["derive"]
 
 [dependencies.cobs]
-version = "0.2.3"
+version = "0.3.0"
 default-features = false
 
 [dependencies.defmt]


### PR DESCRIPTION
Looking at https://github.com/jamesmunns/cobs.rs/blob/main/CHANGELOG.md#v030-2025-01-31, it seems like there is no reason not to depend on the latest version of `cobs`. I confirmed that `cargo test --workspace` still passes.