### PR TITLE
Update postcard’s dep. on postcard-derive to 0.2

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -54,7 +54,7 @@ version = "0.6"
 optional = true
 
 [dependencies.postcard-derive]
-version = "0.1.2"
+version = "0.2.0"
 optional = true
 
 [dependencies.crc]


### PR DESCRIPTION
It seems like the current version of `postcard` should depend on the current version (SemVer-wise) of `postcard-derive`…

I confirmed that `cargo test --workspace` still passes.