### PR TITLE
Implement `Schema` for `Cow`

### DIFF
--- a/source/postcard-schema/src/impls/builtins_alloc.rs
+++ b/source/postcard-schema/src/impls/builtins_alloc.rs
@@ -22,3 +22,7 @@ impl<K: Schema, V: Schema> Schema for alloc::collections::BTreeMap<K, V> {
 impl<K: Schema> Schema for alloc::collections::BTreeSet<K> {
     const SCHEMA: &'static DataModelType = &DataModelType::Seq(K::SCHEMA);
 }
+
+impl<T: ?Sized + Schema + alloc::borrow::ToOwned> Schema for alloc::borrow::Cow<'_, T> {
+    const SCHEMA: &'static DataModelType = T::SCHEMA;
+}

--- a/source/postcard-schema/src/impls/builtins_std.rs
+++ b/source/postcard-schema/src/impls/builtins_std.rs
@@ -42,3 +42,8 @@ impl<K: Schema> Schema for std::collections::HashSet<K> {
 impl<K: Schema> Schema for std::collections::BTreeSet<K> {
     const SCHEMA: &'static DataModelType = &DataModelType::Seq(K::SCHEMA);
 }
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: ?Sized + Schema + std::borrow::ToOwned> Schema for std::borrow::Cow<'_, T> {
+    const SCHEMA: &'static DataModelType = T::SCHEMA;
+}


### PR DESCRIPTION
This PR implements `Schema` for `alloc::borrow::Cow` and `std::alloc::Cow`, similarly to the existing implementations.