### PR TITLE
Version bump defmt to 1.x.x

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -40,7 +40,7 @@ version = "0.2.3"
 default-features = false
 
 [dependencies.defmt]
-version = "0.3"
+version = "1"
 optional = true
 
 [dependencies.embedded-io-04]


### PR DESCRIPTION
Bumps optional defmt dependency up to version 1.x.x.

I don't know what else to say. This is the smallest PR I've made in my life.