### PR TITLE
Mark `Key::from_bytes` as safe

### DIFF
--- a/source/postcard-schema/src/key/mod.rs
+++ b/source/postcard-schema/src/key/mod.rs
@@ -65,14 +65,8 @@ impl Key {
         Key(hash::fnv1a64::hash_ty_path::<T>(path))
     }
 
-    /// Unsafely create a key from a given 8-byte value
-    ///
-    /// ## Safety
-    ///
-    /// This MUST only be used with pre-calculated values. Incorrectly
-    /// created keys could lead to the improper deserialization of
-    /// messages.
-    pub const unsafe fn from_bytes(bytes: [u8; 8]) -> Self {
+    /// Create a key from a given 8-byte value
+    pub const fn from_bytes(bytes: [u8; 8]) -> Self {
         Self(bytes)
     }
 

--- a/source/postcard-schema/src/key/mod.rs
+++ b/source/postcard-schema/src/key/mod.rs
@@ -66,6 +66,11 @@ impl Key {
     }
 
     /// Create a key from a given 8-byte value
+    ///
+    /// NOTE: Since [`Key`]s should never be used to replace full type safety,
+    /// creating a "wrong" Key should not be unsafe. However, using a "wrong"
+    /// key (which doesn't match the type being deserialized) may cause confusion,
+    /// so manually creating keys should be avoided whenever possible.
     pub const fn from_bytes(bytes: [u8; 8]) -> Self {
         Self(bytes)
     }


### PR DESCRIPTION
It doesn't seem to make sense to me as to why this is unsafe, when you have a safe constructor that takes an arbitrary string whose Key you could still use incorrectly. But also more importantly, `Key` implements `Deserialize` which means it is already possible to create abitrary keys via deserialization with arbitrary inputs.

So either this constructor ought to be safe, or `Key::for_path` needs to be also `unsafe` and the `Deserialize` impl has to be removed.