### PR TITLE
Implement Schema and MaxSize for more core types

### DIFF
--- a/source/postcard-schema/Cargo.toml
+++ b/source/postcard-schema/Cargo.toml
@@ -86,6 +86,7 @@ alloc = ["serde/alloc"]
 derive = ["postcard-derive"]
 
 core-net = []
+core-num-saturating = []
 
 defmt-v0_3 = ["defmt_v0_3"]
 uuid-v1_0 = ["uuid_v1_0"]

--- a/source/postcard-schema/src/impls/builtins_nostd.rs
+++ b/source/postcard-schema/src/impls/builtins_nostd.rs
@@ -7,11 +7,13 @@ use crate::{
     Schema,
 };
 use core::{
+    marker::PhantomData,
     num::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
         NonZeroU32, NonZeroU64, NonZeroU8,
     },
     ops::{Range, RangeFrom, RangeInclusive, RangeTo},
+    time::Duration,
 };
 
 macro_rules! impl_schema {
@@ -238,5 +240,38 @@ impl Schema for core::net::SocketAddr {
                 data: Data::Newtype(core::net::SocketAddrV6::SCHEMA),
             },
         ],
+    };
+}
+
+impl<T: Schema> Schema for core::num::Wrapping<T> {
+    const SCHEMA: &'static DataModelType = T::SCHEMA;
+}
+
+#[cfg(feature = "core-num-saturating")]
+#[cfg_attr(docsrs, doc(cfg(feature = "core-num-saturating")))]
+impl<T: Schema> Schema for core::num::Saturating<T> {
+    const SCHEMA: &'static DataModelType = T::SCHEMA;
+}
+
+impl Schema for Duration {
+    const SCHEMA: &'static DataModelType = &DataModelType::Struct {
+        name: "Duration",
+        data: Data::Struct(&[
+            &NamedField {
+                name: "secs",
+                ty: u64::SCHEMA,
+            },
+            &NamedField {
+                name: "nanos",
+                ty: u32::SCHEMA,
+            },
+        ]),
+    };
+}
+
+impl<T: ?Sized> Schema for PhantomData<T> {
+    const SCHEMA: &'static DataModelType = &DataModelType::Struct {
+        name: "PhantomData",
+        data: Data::Unit,
     };
 }

--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -82,6 +82,7 @@ use-crc = ["crc"]
 #
 # NOT subject to SemVer guarantees!
 experimental-derive = ["postcard-derive"]
+core-num-saturating = []
 crc = ["dep:crc"]
 defmt = ["dep:defmt"]
 heapless = ["dep:heapless"]

--- a/source/postcard/src/max_size.rs
+++ b/source/postcard/src/max_size.rs
@@ -15,6 +15,7 @@ use core::{
         NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
     },
     ops::{Range, RangeFrom, RangeInclusive, RangeTo},
+    time::Duration,
 };
 
 /// This trait is used to enforce the maximum size required to
@@ -161,6 +162,10 @@ impl MaxSize for NonZeroUsize {
     const POSTCARD_MAX_SIZE: usize = usize::POSTCARD_MAX_SIZE;
 }
 
+impl MaxSize for Duration {
+    const POSTCARD_MAX_SIZE: usize = u64::POSTCARD_MAX_SIZE + u32::POSTCARD_MAX_SIZE;
+}
+
 impl<T> MaxSize for PhantomData<T> {
     const POSTCARD_MAX_SIZE: usize = 0;
 }
@@ -215,6 +220,16 @@ impl<T: MaxSize> MaxSize for RangeFrom<T> {
 }
 
 impl<T: MaxSize> MaxSize for RangeTo<T> {
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
+}
+
+impl<T: MaxSize> MaxSize for core::num::Wrapping<T> {
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
+}
+
+#[cfg(all(feature = "core-num-saturating", feature = "experimental-derive"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "core-num-saturating")))]
+impl<T: MaxSize> MaxSize for core::num::Saturating<T> {
     const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
 }
 


### PR DESCRIPTION
- `core::time::Duration`
- `core::marker::PhantomData`
- `core::num::{Wrapping,Saturating}`
  - Added feature flags for `Saturating` since it's relatively new (1.74)