### PR TITLE
Upgrade heapless to 0.8.

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 
 [dependencies.heapless]
-version = "0.7.0"
+version = "0.8.0"
 default-features = false
 features = ["serde"]
 optional = true
@@ -79,7 +79,7 @@ embedded-io-04 = ["dep:embedded-io-04"]
 embedded-io-06 = ["dep:embedded-io-06"]
 
 use-std = ["serde/std", "alloc"]
-heapless-cas = ["heapless", "dep:heapless", "heapless/cas"]
+heapless-cas = ["heapless", "dep:heapless", "heapless/portable-atomic"]
 alloc = ["serde/alloc", "embedded-io-04?/alloc", "embedded-io-06?/alloc"]
 use-defmt = ["defmt"]
 use-crc = ["crc"]


### PR DESCRIPTION
Change feature flag from `cas` to `portable-atomic`.

All the tests continue to pass.

For context, this is important to me as I am using the `atat` crate and it's implementation of `AtatCmd` for `heapless::String<N>` and the conflicting versions of heapless make it impossible for me to compile with both `postcard` and `atat`.

Thanks 🙏 