### PR TITLE
Fix typos

### DIFF
--- a/source/postcard/src/fixint.rs
+++ b/source/postcard/src/fixint.rs
@@ -1,7 +1,7 @@
 //! # Fixed Size Integers
 //!
 //! In some cases, the use of variably length encoded data may not be
-//! preferrable. These modules, for use with `#[serde(with = ...)]`
+//! preferable. These modules, for use with `#[serde(with = ...)]`
 //! "opt out" of variable length encoding.
 //!
 //! Support explicitly not provided for `usize` or `isize`, as

--- a/spec/src/serde-data-model.md
+++ b/spec/src/serde-data-model.md
@@ -126,7 +126,7 @@ Values of each element of the `tuple` may have differing values.
 
 ### 25 - `tuple_struct`
 
-A type representing a named type specifcally containing exactly one `tuple` Serde Data Type
+A type representing a named type specifically containing exactly one `tuple` Serde Data Type
 
 ### 26 - `tuple_variant`
 


### PR DESCRIPTION


**Description:**

This PR fixes a couple of typos in a comment and the spec document.

- `preferrable` -> `preferable`
- `specifcally` -> `specifically`