### PR TITLE
Add dummy "paste" feature

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -84,6 +84,9 @@ alloc = ["serde/alloc", "embedded-io-04?/alloc", "embedded-io-06?/alloc"]
 use-defmt = ["defmt"]
 use-crc = ["crc"]
 
+# Does nothing, for compat only
+paste = []
+
 # Experimental features!
 #
 # NOT subject to SemVer guarantees!


### PR DESCRIPTION
This adds back a "paste" feature that was removed in #222

cargo-semver-checks flags this as a semver compat issue.