### PR TITLE
Implement Schema for Arguments

### DIFF
--- a/source/postcard-schema-ng/src/impls/builtins_nostd.rs
+++ b/source/postcard-schema-ng/src/impls/builtins_nostd.rs
@@ -7,6 +7,7 @@ use crate::{
     Schema,
 };
 use core::{
+    fmt::Arguments,
     marker::PhantomData,
     num::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
@@ -274,4 +275,8 @@ impl<T: ?Sized> Schema for PhantomData<T> {
         name: "PhantomData",
         data: Data::Unit,
     };
+}
+
+impl Schema for Arguments<'_> {
+    const SCHEMA: &'static crate::schema::DataModelType = &DataModelType::String;
 }

--- a/source/postcard-schema/src/impls/builtins_nostd.rs
+++ b/source/postcard-schema/src/impls/builtins_nostd.rs
@@ -7,6 +7,7 @@ use crate::{
     Schema,
 };
 use core::{
+    fmt::Arguments,
     marker::PhantomData,
     num::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
@@ -286,5 +287,12 @@ impl<T: ?Sized> Schema for PhantomData<T> {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "PhantomData",
         ty: &DataModelType::Unit,
+    };
+}
+
+impl Schema for Arguments<'_> {
+    const SCHEMA: &'static crate::schema::NamedType = &NamedType {
+        name: "Arguments",
+        ty: &DataModelType::String,
     };
 }


### PR DESCRIPTION
`Arguments<'_>` implements `Serialize` by collecting into a string: https://github.com/serde-rs/serde/blob/babafa54d283fb087fa94f50a2cf82fa9e582a7c/serde/src/ser/impls.rs#L62-L69

This works using this path of `postcard`: https://github.com/jamesmunns/postcard/blob/718aa6a6850456017c19eeff67303c633f875736/source/postcard/src/ser/serializer.rs#L320-L388