### PR TITLE
Add heapless v0.8 and v0.9 MaxSize impls for postcard 1.x

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -30,6 +30,20 @@ default-features = false
 features = ["serde"]
 optional = true
 
+[dependencies.heapless-v0_8]
+package = "heapless"
+version = "0.8.0"
+default-features = false
+features = ["serde"]
+optional = true
+
+[dependencies.heapless-v0_9]
+package = "heapless"
+version = "0.9.1"
+default-features = false
+features = ["serde"]
+optional = true
+
 [dependencies.serde]
 version = "1.0.100"
 default-features = false
@@ -101,3 +115,5 @@ crc = ["dep:crc"]
 defmt = ["dep:defmt"]
 heapless = ["dep:heapless"]
 postcard-derive = ["dep:postcard-derive"]
+heapless-v0_8 = ["dep:heapless-v0_8"]
+heapless-v0_9 = ["dep:heapless-v0_9"]

--- a/source/postcard/src/max_size.rs
+++ b/source/postcard/src/max_size.rs
@@ -263,6 +263,30 @@ impl<const N: usize> MaxSize for heapless::String<N> {
     const POSTCARD_MAX_SIZE: usize = <[u8; N]>::POSTCARD_MAX_SIZE + varint_size(N);
 }
 
+#[cfg(feature = "heapless-v0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless-v0_8")))]
+impl<T: MaxSize, const N: usize> MaxSize for heapless_v0_8::Vec<T, N> {
+    const POSTCARD_MAX_SIZE: usize = <[T; N]>::POSTCARD_MAX_SIZE + varint_size(N);
+}
+
+#[cfg(feature = "heapless-v0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless-v0_8")))]
+impl<const N: usize> MaxSize for heapless_v0_8::String<N> {
+    const POSTCARD_MAX_SIZE: usize = <[u8; N]>::POSTCARD_MAX_SIZE + varint_size(N);
+}
+
+#[cfg(feature = "heapless-v0_9")]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless-v0_9")))]
+impl<T: MaxSize, const N: usize> MaxSize for heapless_v0_9::Vec<T, N> {
+    const POSTCARD_MAX_SIZE: usize = <[T; N]>::POSTCARD_MAX_SIZE + varint_size(N);
+}
+
+#[cfg(feature = "heapless-v0_9")]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless-v0_9")))]
+impl<const N: usize> MaxSize for heapless_v0_9::String<N> {
+    const POSTCARD_MAX_SIZE: usize = <[u8; N]>::POSTCARD_MAX_SIZE + varint_size(N);
+}
+
 #[cfg(all(feature = "nalgebra-v0_33", feature = "experimental-derive"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "nalgebra-v0_33")))]
 impl<T, const R: usize, const C: usize> MaxSize
@@ -290,7 +314,11 @@ impl<T: MaxSize + nalgebra_v0_33::Scalar> MaxSize for nalgebra_v0_33::Quaternion
     const POSTCARD_MAX_SIZE: usize = nalgebra_v0_33::Vector4::<T>::POSTCARD_MAX_SIZE;
 }
 
-#[cfg(feature = "heapless")]
+#[cfg(any(
+    feature = "heapless",
+    feature = "heapless-v0_8",
+    feature = "heapless-v0_9"
+))]
 const fn varint_size(max_n: usize) -> usize {
     const BITS_PER_BYTE: usize = 8;
     const BITS_PER_VARINT_BYTE: usize = 7;


### PR DESCRIPTION
While I understand bumping the main `heapless` in this crate is something reserved for postcard 2 as it is a breaking change, it would be nice to optionally have `MaxSize` implementations for newer versions of `heapless` as a stopgap before an upgrade to `postcard` 2 is made at some point in the future, potentially also bringing further refactors that eliminate the need for these impls.

This doesn't touch `to_vec` or similar methods; I don't see a way of editing those without breaking semver and you still get a lot of utility out of `MaxSize` impls anyway.