### PR TITLE
Make varint serialization faster

### DIFF
--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -71,6 +71,14 @@ version = "1.0.100"
 default-features = false
 features = ["derive"]
 
+[dev-dependencies.criterion]
+version = "0.7"
+features = ["html_reports"]
+
+[[bench]]
+name = "varint_bench"
+harness = false
+
 [features]
 default = ["heapless-cas"]
 
@@ -87,6 +95,7 @@ heapless-cas = ["heapless", "dep:heapless", "heapless/cas"]
 alloc = ["serde/alloc", "embedded-io-04?/alloc", "embedded-io-06?/alloc"]
 use-defmt = ["defmt"]
 use-crc = ["crc"]
+bench_private = []
 
 # Does nothing, for compat only
 paste = []

--- a/source/postcard/benches/varint_bench.rs
+++ b/source/postcard/benches/varint_bench.rs
@@ -1,0 +1,229 @@
+use criterion::criterion_main;
+#[cfg(feature = "bench_private")]
+mod bench {
+    use criterion::{criterion_group, Criterion};
+    use postcard::varint::{
+        varint_max, varint_u128, varint_u16, varint_u32, varint_u64, varint_usize,
+    };
+    use std::hint::black_box;
+
+    // usize benchmarks
+    fn bench_varint_usize_small(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<usize>()];
+        c.bench_function("varint_usize_small", |b| {
+            b.iter(|| {
+                let _ = varint_usize(black_box(42), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_usize_medium(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<usize>()];
+        c.bench_function("varint_usize_medium", |b| {
+            b.iter(|| {
+                let _ = varint_usize(black_box(123456), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_usize_large(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<usize>()];
+        c.bench_function("varint_usize_large", |b| {
+            b.iter(|| {
+                let _ = varint_usize(black_box(usize::MAX), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_usize_zero(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<usize>()];
+        c.bench_function("varint_usize_zero", |b| {
+            b.iter(|| {
+                let _ = varint_usize(black_box(0), black_box(&mut out));
+            })
+        });
+    }
+
+    // u16 benchmarks
+    fn bench_varint_u16_small(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u16>()];
+        c.bench_function("varint_u16_small", |b| {
+            b.iter(|| {
+                let _ = varint_u16(black_box(42), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u16_medium(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u16>()];
+        c.bench_function("varint_u16_medium", |b| {
+            b.iter(|| {
+                let _ = varint_u16(black_box(1234), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u16_large(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u16>()];
+        c.bench_function("varint_u16_large", |b| {
+            b.iter(|| {
+                let _ = varint_u16(black_box(u16::MAX), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u16_zero(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u16>()];
+        c.bench_function("varint_u16_zero", |b| {
+            b.iter(|| {
+                let _ = varint_u16(black_box(0), black_box(&mut out));
+            })
+        });
+    }
+
+    // u32 benchmarks
+    fn bench_varint_u32_small(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u32>()];
+        c.bench_function("varint_u32_small", |b| {
+            b.iter(|| {
+                let _ = varint_u32(black_box(42), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u32_medium(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u32>()];
+        c.bench_function("varint_u32_medium", |b| {
+            b.iter(|| {
+                let _ = varint_u32(black_box(123456), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u32_large(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u32>()];
+        c.bench_function("varint_u32_large", |b| {
+            b.iter(|| {
+                let _ = varint_u32(black_box(u32::MAX), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u32_zero(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u32>()];
+        c.bench_function("varint_u32_zero", |b| {
+            b.iter(|| {
+                let _ = varint_u32(black_box(0), black_box(&mut out));
+            })
+        });
+    }
+
+    // u64 benchmarks
+    fn bench_varint_u64_small(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u64>()];
+        c.bench_function("varint_u64_small", |b| {
+            b.iter(|| {
+                let _ = varint_u64(black_box(42), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u64_medium(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u64>()];
+        c.bench_function("varint_u64_medium", |b| {
+            b.iter(|| {
+                let _ = varint_u64(black_box(123456), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u64_large(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u64>()];
+        c.bench_function("varint_u64_large", |b| {
+            b.iter(|| {
+                let _ = varint_u64(black_box(u64::MAX), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u64_zero(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u64>()];
+        c.bench_function("varint_u64_zero", |b| {
+            b.iter(|| {
+                let _ = varint_u64(black_box(0), black_box(&mut out));
+            })
+        });
+    }
+
+    // u128 benchmarks
+    fn bench_varint_u128_small(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u128>()];
+        c.bench_function("varint_u128_small", |b| {
+            b.iter(|| {
+                let _ = varint_u128(black_box(42), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u128_medium(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u128>()];
+        c.bench_function("varint_u128_medium", |b| {
+            b.iter(|| {
+                let _ = varint_u128(black_box(12345678901234567890), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u128_large(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u128>()];
+        c.bench_function("varint_u128_large", |b| {
+            b.iter(|| {
+                let _ = varint_u128(black_box(u128::MAX), black_box(&mut out));
+            })
+        });
+    }
+
+    fn bench_varint_u128_zero(c: &mut Criterion) {
+        let mut out = [0u8; varint_max::<u128>()];
+        c.bench_function("varint_u128_zero", |b| {
+            b.iter(|| {
+                let _ = varint_u128(black_box(0), black_box(&mut out));
+            })
+        });
+    }
+
+    criterion_group!(
+        benches,
+        bench_varint_usize_small,
+        bench_varint_usize_medium,
+        bench_varint_usize_large,
+        bench_varint_usize_zero,
+        bench_varint_u16_small,
+        bench_varint_u16_medium,
+        bench_varint_u16_large,
+        bench_varint_u16_zero,
+        bench_varint_u32_small,
+        bench_varint_u32_medium,
+        bench_varint_u32_large,
+        bench_varint_u32_zero,
+        bench_varint_u64_small,
+        bench_varint_u64_medium,
+        bench_varint_u64_large,
+        bench_varint_u64_zero,
+        bench_varint_u128_small,
+        bench_varint_u128_medium,
+        bench_varint_u128_large,
+        bench_varint_u128_zero
+    );
+}
+
+#[cfg(not(feature = "bench_private"))]
+mod bench {
+    use criterion::{criterion_group, Criterion};
+    fn dummy(_: &mut Criterion) {}
+    criterion_group!(benches, dummy);
+}
+
+use bench::benches;
+
+criterion_main!(benches);

--- a/source/postcard/src/lib.rs
+++ b/source/postcard/src/lib.rs
@@ -11,6 +11,10 @@ mod eio;
 mod error;
 pub mod fixint;
 mod ser;
+#[cfg(feature = "bench_private")]
+#[doc(hidden)]
+pub mod varint;
+#[cfg(not(feature = "bench_private"))]
 mod varint;
 
 // Still experimental! Don't make pub pub.

--- a/source/postcard/src/varint.rs
+++ b/source/postcard/src/varint.rs
@@ -24,6 +24,10 @@ pub const fn max_of_last_byte<T: Sized>() -> u8 {
 
 #[inline]
 pub fn varint_usize(n: usize, out: &mut [u8; varint_max::<usize>()]) -> &mut [u8] {
+    if n < 128 {
+        out[0] = n as u8;
+        return &mut out[..1];
+    }
     let mut value = n;
     let mut i = 0;
     while value >= 128 {
@@ -37,6 +41,10 @@ pub fn varint_usize(n: usize, out: &mut [u8; varint_max::<usize>()]) -> &mut [u8
 
 #[inline]
 pub fn varint_u16(n: u16, out: &mut [u8; varint_max::<u16>()]) -> &mut [u8] {
+    if n < 128 {
+        out[0] = n as u8;
+        return &mut out[..1];
+    }
     let mut value = n;
     let mut i = 0;
     while value >= 128 {
@@ -50,6 +58,10 @@ pub fn varint_u16(n: u16, out: &mut [u8; varint_max::<u16>()]) -> &mut [u8] {
 
 #[inline]
 pub fn varint_u32(n: u32, out: &mut [u8; varint_max::<u32>()]) -> &mut [u8] {
+    if n < 128 {
+        out[0] = n as u8;
+        return &mut out[..1];
+    }
     let mut value = n;
     let mut i = 0;
     while value >= 128 {
@@ -63,6 +75,10 @@ pub fn varint_u32(n: u32, out: &mut [u8; varint_max::<u32>()]) -> &mut [u8] {
 
 #[inline]
 pub fn varint_u64(n: u64, out: &mut [u8; varint_max::<u64>()]) -> &mut [u8] {
+    if n < 128 {
+        out[0] = n as u8;
+        return &mut out[..1];
+    }
     let mut value = n;
     let mut i = 0;
     while value >= 128 {
@@ -76,6 +92,10 @@ pub fn varint_u64(n: u64, out: &mut [u8; varint_max::<u64>()]) -> &mut [u8] {
 
 #[inline]
 pub fn varint_u128(n: u128, out: &mut [u8; varint_max::<u128>()]) -> &mut [u8] {
+    if n < 128 {
+        out[0] = n as u8;
+        return &mut out[..1];
+    }
     let mut value = n;
     let mut i = 0;
     while value >= 128 {

--- a/source/postcard/src/varint.rs
+++ b/source/postcard/src/varint.rs
@@ -25,79 +25,64 @@ pub const fn max_of_last_byte<T: Sized>() -> u8 {
 #[inline]
 pub fn varint_usize(n: usize, out: &mut [u8; varint_max::<usize>()]) -> &mut [u8] {
     let mut value = n;
-    for i in 0..varint_max::<usize>() {
-        out[i] = value.to_le_bytes()[0];
-        if value < 128 {
-            return &mut out[..=i];
-        }
-
-        out[i] |= 0x80;
+    let mut i = 0;
+    while value >= 128 {
+        out[i] = value.to_le_bytes()[0] | 0b10000000;
         value >>= 7;
+        i += 1;
     }
-    debug_assert_eq!(value, 0);
-    &mut out[..]
+    out[i] = value as u8;
+    &mut out[..=i]
 }
 
 #[inline]
 pub fn varint_u16(n: u16, out: &mut [u8; varint_max::<u16>()]) -> &mut [u8] {
     let mut value = n;
-    for i in 0..varint_max::<u16>() {
-        out[i] = value.to_le_bytes()[0];
-        if value < 128 {
-            return &mut out[..=i];
-        }
-
-        out[i] |= 0x80;
+    let mut i = 0;
+    while value >= 128 {
+        out[i] = value.to_le_bytes()[0] | 0b10000000;
         value >>= 7;
+        i += 1;
     }
-    debug_assert_eq!(value, 0);
-    &mut out[..]
+    out[i] = value as u8;
+    &mut out[..=i]
 }
 
 #[inline]
 pub fn varint_u32(n: u32, out: &mut [u8; varint_max::<u32>()]) -> &mut [u8] {
     let mut value = n;
-    for i in 0..varint_max::<u32>() {
-        out[i] = value.to_le_bytes()[0];
-        if value < 128 {
-            return &mut out[..=i];
-        }
-
-        out[i] |= 0x80;
+    let mut i = 0;
+    while value >= 128 {
+        out[i] = value.to_le_bytes()[0] | 0b10000000;
         value >>= 7;
+        i += 1;
     }
-    debug_assert_eq!(value, 0);
-    &mut out[..]
+    out[i] = value as u8;
+    &mut out[..=i]
 }
 
 #[inline]
 pub fn varint_u64(n: u64, out: &mut [u8; varint_max::<u64>()]) -> &mut [u8] {
     let mut value = n;
-    for i in 0..varint_max::<u64>() {
-        out[i] = value.to_le_bytes()[0];
-        if value < 128 {
-            return &mut out[..=i];
-        }
-
-        out[i] |= 0x80;
+    let mut i = 0;
+    while value >= 128 {
+        out[i] = value.to_le_bytes()[0] | 0b10000000;
         value >>= 7;
+        i += 1;
     }
-    debug_assert_eq!(value, 0);
-    &mut out[..]
+    out[i] = value as u8;
+    &mut out[..=i]
 }
 
 #[inline]
 pub fn varint_u128(n: u128, out: &mut [u8; varint_max::<u128>()]) -> &mut [u8] {
     let mut value = n;
-    for i in 0..varint_max::<u128>() {
-        out[i] = value.to_le_bytes()[0];
-        if value < 128 {
-            return &mut out[..=i];
-        }
-
-        out[i] |= 0x80;
+    let mut i = 0;
+    while value >= 128 {
+        out[i] = value.to_le_bytes()[0] | 0b10000000;
         value >>= 7;
+        i += 1;
     }
-    debug_assert_eq!(value, 0);
-    &mut out[..]
+    out[i] = value as u8;
+    &mut out[..=i]
 }


### PR DESCRIPTION
Make the varint serialization a little bit faster. Tested on my M2Max MacBook Pro:

```rust
varint_usize_small      time:   [448.37 ps 449.10 ps 449.95 ps]
                        change: [-2.9078% -2.6660% -2.4087%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe

varint_usize_medium     time:   [859.93 ps 861.07 ps 862.44 ps]
                        change: [-24.991% -24.845% -24.696%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild

varint_usize_large      time:   [2.0006 ns 2.0037 ns 2.0071 ns]
                        change: [-41.360% -41.171% -40.984%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

varint_usize_zero       time:   [448.29 ps 448.90 ps 449.63 ps]
                        change: [-2.7199% -2.4173% -2.1388%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

varint_u16_small        time:   [443.57 ps 444.05 ps 444.61 ps]
                        change: [-5.5019% -5.2316% -4.9470%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe

varint_u16_medium       time:   [608.83 ps 609.43 ps 610.14 ps]
                        change: [-22.827% -22.638% -22.452%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) high mild
  8 (8.00%) high severe

varint_u16_large        time:   [759.94 ps 761.12 ps 762.55 ps]
                        change: [-33.611% -33.385% -33.155%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

varint_u16_zero         time:   [443.63 ps 444.33 ps 445.14 ps]
                        change: [-5.5058% -5.2809% -5.0360%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

varint_u32_small        time:   [447.85 ps 448.64 ps 449.51 ps]
                        change: [-2.0678% -1.8302% -1.6076%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

varint_u32_medium       time:   [859.22 ps 859.96 ps 860.86 ps]
                        change: [-25.391% -25.118% -24.834%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

varint_u32_large        time:   [1.1269 ns 1.1329 ns 1.1444 ns]
                        change: [-39.334% -39.056% -38.708%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

varint_u32_zero         time:   [448.01 ps 448.54 ps 449.16 ps]
                        change: [-4.3074% -4.1158% -3.8823%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) high mild
  11 (11.00%) high severe

varint_u64_small        time:   [448.20 ps 448.81 ps 449.52 ps]
                        change: [-2.5346% -2.2928% -2.0294%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

varint_u64_medium       time:   [859.29 ps 860.39 ps 861.79 ps]
                        change: [-24.462% -24.208% -23.945%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe

varint_u64_large        time:   [1.9988 ns 2.0009 ns 2.0033 ns]
                        change: [-41.638% -41.443% -41.257%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

varint_u64_zero         time:   [455.70 ps 456.78 ps 457.86 ps]
                        change: [-1.2134% -0.9606% -0.7124%] (p = 0.00 < 0.05)
                        Change within noise threshold.

varint_u128_small       time:   [859.39 ps 860.74 ps 862.72 ps]
                        change: [-25.041% -24.809% -24.580%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

varint_u128_medium      time:   [2.6836 ns 2.6873 ns 2.6917 ns]
                        change: [-28.508% -28.318% -28.121%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

varint_u128_large       time:   [4.1398 ns 4.1703 ns 4.2074 ns]
                        change: [-39.806% -39.553% -39.277%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

varint_u128_zero        time:   [859.21 ps 860.04 ps 861.07 ps]
                        change: [-25.278% -24.947% -24.657%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
```

The overall serialization also speeds up a little bit on my private project:

Before:
![img_v3_02q4_2bba778b-38c3-4f81-9b49-bb66cef57cbg](https://github.com/user-attachments/assets/bcc79963-fb6e-4653-8f89-fed6b05bae13)
After:
![img_v3_02q4_b87a6fee-472c-4f59-9761-3e9179ea9f0g](https://github.com/user-attachments/assets/5090a9cf-6935-4874-b766-6f6ab2030728)
