### PR TITLE
docs: Fix copy-paste-o (heapless::Vec -> std::vec::Vec).

### DIFF
--- a/source/postcard/src/ser/mod.rs
+++ b/source/postcard/src/ser/mod.rs
@@ -385,7 +385,7 @@ where
     flavors::crc::to_vec_u32(value, digest)
 }
 
-/// Conveniently serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
+/// Conveniently serialize a `T` to a `std::vec::Vec<u8>`, with the `Vec` containing
 /// data followed by a 32-bit  CRC. The CRC bytes are included in the output `Vec`.
 ///
 /// ## Example
@@ -416,7 +416,7 @@ where
     flavors::crc::to_allocvec_u32(value, digest)
 }
 
-/// Conveniently serialize a `T` to a `heapless::Vec<u8>`, with the `Vec` containing
+/// Conveniently serialize a `T` to an `alloc::vec::Vec<u8>`, with the `Vec` containing
 /// data followed by a 32-bit  CRC. The CRC bytes are included in the output `Vec`.
 ///
 /// ## Example


### PR DESCRIPTION
Fixes an error in the doc comments for `to_stdvec_crc32()`, which currently says it returns a `heapless::Vec` instead of a `std::vec::Vec`.