### PR TITLE
Implement `postcard_schema::Schema` for `VecDeque`, `Rc`, and `Arc`

### DIFF
--- a/source/postcard-schema-ng/src/impls/builtins_alloc.rs
+++ b/source/postcard-schema-ng/src/impls/builtins_alloc.rs
@@ -28,11 +28,26 @@ impl<K: Schema> Schema for alloc::collections::BTreeSet<K> {
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for alloc::collections::VecDeque<T> {
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(T::SCHEMA);
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: Schema> Schema for alloc::boxed::Box<T> {
     const SCHEMA: &'static DataModelType = T::SCHEMA;
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: ?Sized + Schema + alloc::borrow::ToOwned> Schema for alloc::borrow::Cow<'_, T> {
+    const SCHEMA: &'static DataModelType = T::SCHEMA;
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for alloc::rc::Rc<T> {
+    const SCHEMA: &'static DataModelType = T::SCHEMA;
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for alloc::sync::Arc<T> {
     const SCHEMA: &'static DataModelType = T::SCHEMA;
 }

--- a/source/postcard-schema-ng/src/impls/builtins_alloc.rs
+++ b/source/postcard-schema-ng/src/impls/builtins_alloc.rs
@@ -46,8 +46,3 @@ impl<T: ?Sized + Schema + alloc::borrow::ToOwned> Schema for alloc::borrow::Cow<
 impl<T: Schema> Schema for alloc::rc::Rc<T> {
     const SCHEMA: &'static DataModelType = T::SCHEMA;
 }
-
-#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
-impl<T: Schema> Schema for alloc::sync::Arc<T> {
-    const SCHEMA: &'static DataModelType = T::SCHEMA;
-}

--- a/source/postcard-schema-ng/src/impls/builtins_std.rs
+++ b/source/postcard-schema-ng/src/impls/builtins_std.rs
@@ -44,11 +44,26 @@ impl<K: Schema> Schema for std::collections::BTreeSet<K> {
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for std::collections::VecDeque<T> {
+    const SCHEMA: &'static DataModelType = &DataModelType::Seq(T::SCHEMA);
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: Schema> Schema for std::boxed::Box<T> {
     const SCHEMA: &'static DataModelType = T::SCHEMA;
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: ?Sized + Schema + std::borrow::ToOwned> Schema for std::borrow::Cow<'_, T> {
+    const SCHEMA: &'static DataModelType = T::SCHEMA;
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for std::rc::Rc<T> {
+    const SCHEMA: &'static DataModelType = T::SCHEMA;
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for std::sync::Arc<T> {
     const SCHEMA: &'static DataModelType = T::SCHEMA;
 }

--- a/source/postcard-schema-ng/tests/schema.rs
+++ b/source/postcard-schema-ng/tests/schema.rs
@@ -356,6 +356,9 @@ fn smoke() {
         (dewit::<Option<Classic>>, "Option<Classic>"),
         (dewit::<Option<ClassicGen<i32>>>, "Option<ClassicGen>"),
         (dewit::<PathBuf>, "String"),
+        (dewit::<std::collections::VecDeque<u32>>, "[u32]"),
+        (dewit::<std::rc::Rc<u32>>, "u32"),
+        (dewit::<std::sync::Arc<u32>>, "u32"),
     ];
     for (f, s) in tests {
         assert_eq!(f().as_str(), *s);

--- a/source/postcard-schema/src/impls/builtins_alloc.rs
+++ b/source/postcard-schema/src/impls/builtins_alloc.rs
@@ -43,6 +43,14 @@ impl<K: Schema> Schema for alloc::collections::BTreeSet<K> {
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for alloc::collections::VecDeque<T> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "VecDeque<T>",
+        ty: &DataModelType::Seq(T::SCHEMA),
+    };
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: Schema> Schema for alloc::boxed::Box<T> {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "Box<T>",
@@ -54,6 +62,22 @@ impl<T: Schema> Schema for alloc::boxed::Box<T> {
 impl<T: ?Sized + Schema + alloc::borrow::ToOwned> Schema for alloc::borrow::Cow<'_, T> {
     const SCHEMA: &'static NamedType = &NamedType {
         name: "Cow<'_, T>",
+        ty: T::SCHEMA.ty,
+    };
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for alloc::rc::Rc<T> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "Rc<T>",
+        ty: T::SCHEMA.ty,
+    };
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for alloc::sync::Arc<T> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "Arc<T>",
         ty: T::SCHEMA.ty,
     };
 }

--- a/source/postcard-schema/src/impls/builtins_alloc.rs
+++ b/source/postcard-schema/src/impls/builtins_alloc.rs
@@ -73,11 +73,3 @@ impl<T: Schema> Schema for alloc::rc::Rc<T> {
         ty: T::SCHEMA.ty,
     };
 }
-
-#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
-impl<T: Schema> Schema for alloc::sync::Arc<T> {
-    const SCHEMA: &'static NamedType = &NamedType {
-        name: "Arc<T>",
-        ty: T::SCHEMA.ty,
-    };
-}

--- a/source/postcard-schema/src/impls/builtins_std.rs
+++ b/source/postcard-schema/src/impls/builtins_std.rs
@@ -68,6 +68,14 @@ impl<K: Schema> Schema for std::collections::BTreeSet<K> {
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for std::collections::VecDeque<T> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "VecDeque<T>",
+        ty: &DataModelType::Seq(T::SCHEMA),
+    };
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: Schema> Schema for std::boxed::Box<T> {
     const SCHEMA: &'static NamedType = T::SCHEMA;
 }
@@ -75,4 +83,20 @@ impl<T: Schema> Schema for std::boxed::Box<T> {
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
 impl<T: ?Sized + Schema + std::borrow::ToOwned> Schema for std::borrow::Cow<'_, T> {
     const SCHEMA: &'static NamedType = T::SCHEMA;
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for std::rc::Rc<T> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "Rc<T>",
+        ty: T::SCHEMA.ty,
+    };
+}
+
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "use-std"))))]
+impl<T: Schema> Schema for std::sync::Arc<T> {
+    const SCHEMA: &'static NamedType = &NamedType {
+        name: "Arc<T>",
+        ty: T::SCHEMA.ty,
+    };
 }

--- a/source/postcard-schema/tests/schema.rs
+++ b/source/postcard-schema/tests/schema.rs
@@ -400,6 +400,9 @@ fn smoke() {
         (dewit::<Option<Classic>>, "Option<Classic>"),
         (dewit::<Option<ClassicGen<i32>>>, "Option<ClassicGen>"),
         (dewit::<PathBuf>, "String"),
+        (dewit::<std::collections::VecDeque<u32>>, "[u32]"),
+        (dewit::<std::rc::Rc<u32>>, "u32"),
+        (dewit::<std::sync::Arc<u32>>, "u32"),
     ];
     for (f, s) in tests {
         assert_eq!(f().as_str(), *s);


### PR DESCRIPTION
These are standard library types so I assume they are uncontroversial. I followed the existing conventions for these types.

(Side question: I understand the postcard-schema/postcard-schema-dyn split, but why do we need to implement the same schemas for both alloc and std, why can't std reuse the alloc implementations?)