### PR TITLE
[postcard-derive] Ignore zeroes in enum size calculation to avoid large if blocks

### DIFF
--- a/source/postcard-derive/src/max_size.rs
+++ b/source/postcard-derive/src/max_size.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Span, TokenStream, Literal};
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{
     parse_macro_input, parse_quote, spanned::Spanned, Data, DeriveInput, Fields, GenericParam,

--- a/source/postcard-derive/src/max_size.rs
+++ b/source/postcard-derive/src/max_size.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::{Span, TokenStream, Literal};
 use quote::{quote, quote_spanned};
 use syn::{
     parse_macro_input, parse_quote, spanned::Spanned, Data, DeriveInput, Fields, GenericParam,
@@ -41,11 +41,11 @@ fn add_trait_bounds(mut generics: Generics) -> Generics {
 /// Generate a constant expression that sums up the maximum size of the type.
 fn max_size_sum(data: &Data, span: Span) -> Result<TokenStream, syn::Error> {
     match data {
-        Data::Struct(data) => Ok(sum_fields(&data.fields)),
+        Data::Struct(data) => Ok(sum_fields(&data.fields).unwrap_or(quote!(0))),
         Data::Enum(data) => {
             let variant_count = data.variants.len();
 
-            let recurse = data.variants.iter().map(|v| sum_fields(&v.fields));
+            let recurse = data.variants.iter().map(|v| sum_fields(&v.fields)).filter_map(|v| v);
 
             let discriminant_size = varint_size_discriminant(variant_count as u32) as usize;
 
@@ -75,7 +75,7 @@ fn max_size_sum(data: &Data, span: Span) -> Result<TokenStream, syn::Error> {
     }
 }
 
-fn sum_fields(fields: &Fields) -> TokenStream {
+fn sum_fields(fields: &Fields) -> Option<TokenStream> {
     match fields {
         syn::Fields::Named(fields) => {
             // Expands to an expression like
@@ -89,9 +89,9 @@ fn sum_fields(fields: &Fields) -> TokenStream {
                 quote_spanned! { f.span() => <#ty as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE }
             });
 
-            quote! {
+            Some(quote! {
                 0 #(+ #recurse)*
-            }
+            })
         }
         syn::Fields::Unnamed(fields) => {
             let recurse = fields.unnamed.iter().map(|f| {
@@ -99,11 +99,11 @@ fn sum_fields(fields: &Fields) -> TokenStream {
                 quote_spanned! { f.span() => <#ty as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE }
             });
 
-            quote! {
+            Some(quote! {
                 0 #(+ #recurse)*
-            }
+            })
         }
-        syn::Fields::Unit => quote!(0),
+        syn::Fields::Unit => None,
     }
 }
 

--- a/source/postcard-derive/src/max_size.rs
+++ b/source/postcard-derive/src/max_size.rs
@@ -45,7 +45,7 @@ fn max_size_sum(data: &Data, span: Span) -> Result<TokenStream, syn::Error> {
         Data::Enum(data) => {
             let variant_count = data.variants.len();
 
-            let recurse = data.variants.iter().map(|v| sum_fields(&v.fields)).filter_map(|v| v);
+            let recurse = data.variants.iter().filter_map(|v| sum_fields(&v.fields));
 
             let discriminant_size = varint_size_discriminant(variant_count as u32) as usize;
 


### PR DESCRIPTION
Resolves https://github.com/HaoboGu/rmk/issues/691.

This skips the zeroes in the size type calculation in order to compress the resulting tree generated.