### PR TITLE
[postcard-derive] Optimize derive(MaxSize) codegen

### DIFF
--- a/source/postcard-derive-ng/src/max_size.rs
+++ b/source/postcard-derive-ng/src/max_size.rs
@@ -41,28 +41,17 @@ fn add_trait_bounds(mut generics: Generics) -> Generics {
 /// Generate a constant expression that sums up the maximum size of the type.
 fn max_size_sum(data: &Data, span: Span) -> Result<TokenStream, syn::Error> {
     match data {
-        Data::Struct(data) => Ok(sum_fields(&data.fields)),
+        Data::Struct(data) => Ok(sum_fields(&data.fields).unwrap_or(quote!(0))),
         Data::Enum(data) => {
             let variant_count = data.variants.len();
 
-            let recurse = data.variants.iter().map(|v| sum_fields(&v.fields));
+            let variant_sizes = data.variants.iter().filter_map(|v| sum_fields(&v.fields));
 
             let discriminant_size = varint_size_discriminant(variant_count as u32) as usize;
 
-            // Generate a tree of max expressions.
-            let max = recurse.fold(quote!(0), |acc, x| {
-                quote! {
-                    {
-                        let lhs = #acc;
-                        let rhs = #x;
-                        if lhs > rhs {
-                            lhs
-                        } else {
-                            rhs
-                        }
-                    }
-                }
-            });
+            let max = quote! {
+                ::postcard2::experimental::max_size::max_of_variants(&[#(#variant_sizes),*])
+            };
 
             Ok(quote! {
                 #discriminant_size + #max
@@ -75,12 +64,12 @@ fn max_size_sum(data: &Data, span: Span) -> Result<TokenStream, syn::Error> {
     }
 }
 
-fn sum_fields(fields: &Fields) -> TokenStream {
+fn sum_fields(fields: &Fields) -> Option<TokenStream> {
     match fields {
         syn::Fields::Named(fields) => {
             // Expands to an expression like
             //
-            //    0 + <Field1Type>::POSTCARD_MAX_SIZE + <Field2Type>::POSTCARD_MAX_SIZE + ...
+            //    <Field1Type>::POSTCARD_MAX_SIZE + <Field2Type>::POSTCARD_MAX_SIZE + ...
             //
             // but using fully qualified syntax.
 
@@ -89,9 +78,11 @@ fn sum_fields(fields: &Fields) -> TokenStream {
                 quote_spanned! { f.span() => <#ty as ::postcard2::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE }
             });
 
-            quote! {
-                0 #(+ #recurse)*
-            }
+            (!fields.named.is_empty()).then(|| {
+                quote! {
+                    #(#recurse)+*
+                }
+            })
         }
         syn::Fields::Unnamed(fields) => {
             let recurse = fields.unnamed.iter().map(|f| {
@@ -99,11 +90,13 @@ fn sum_fields(fields: &Fields) -> TokenStream {
                 quote_spanned! { f.span() => <#ty as ::postcard2::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE }
             });
 
-            quote! {
-                0 #(+ #recurse)*
-            }
+            (!fields.unnamed.is_empty()).then(|| {
+                quote! {
+                    #(#recurse)+*
+                }
+            })
         }
-        syn::Fields::Unit => quote!(0),
+        syn::Fields::Unit => None,
     }
 }
 

--- a/source/postcard-derive/src/max_size.rs
+++ b/source/postcard-derive/src/max_size.rs
@@ -45,24 +45,13 @@ fn max_size_sum(data: &Data, span: Span) -> Result<TokenStream, syn::Error> {
         Data::Enum(data) => {
             let variant_count = data.variants.len();
 
-            let recurse = data.variants.iter().filter_map(|v| sum_fields(&v.fields));
+            let variant_sizes = data.variants.iter().filter_map(|v| sum_fields(&v.fields));
 
             let discriminant_size = varint_size_discriminant(variant_count as u32) as usize;
 
-            // Generate a tree of max expressions.
-            let max = recurse.fold(quote!(0), |acc, x| {
-                quote! {
-                    {
-                        let lhs = #acc;
-                        let rhs = #x;
-                        if lhs > rhs {
-                            lhs
-                        } else {
-                            rhs
-                        }
-                    }
-                }
-            });
+            let max = quote! {
+                ::postcard::experimental::max_size::max_of_variants(&[#(#variant_sizes),*])
+            };
 
             Ok(quote! {
                 #discriminant_size + #max
@@ -80,7 +69,7 @@ fn sum_fields(fields: &Fields) -> Option<TokenStream> {
         syn::Fields::Named(fields) => {
             // Expands to an expression like
             //
-            //    0 + <Field1Type>::POSTCARD_MAX_SIZE + <Field2Type>::POSTCARD_MAX_SIZE + ...
+            //    <Field1Type>::POSTCARD_MAX_SIZE + <Field2Type>::POSTCARD_MAX_SIZE + ...
             //
             // but using fully qualified syntax.
 
@@ -89,8 +78,10 @@ fn sum_fields(fields: &Fields) -> Option<TokenStream> {
                 quote_spanned! { f.span() => <#ty as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE }
             });
 
-            Some(quote! {
-                0 #(+ #recurse)*
+            (!fields.named.is_empty()).then(|| {
+                quote! {
+                    #(#recurse)+*
+                }
             })
         }
         syn::Fields::Unnamed(fields) => {
@@ -99,8 +90,10 @@ fn sum_fields(fields: &Fields) -> Option<TokenStream> {
                 quote_spanned! { f.span() => <#ty as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE }
             });
 
-            Some(quote! {
-                0 #(+ #recurse)*
+            (!fields.unnamed.is_empty()).then(|| {
+                quote! {
+                    #(#recurse)+*
+                }
             })
         }
         syn::Fields::Unit => None,

--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -69,6 +69,7 @@ optional = true
 [dependencies.postcard-derive]
 version = "0.2.0"
 optional = true
+path = "../postcard-derive"
 
 [dependencies.crc]
 version = "3.0.1"

--- a/source/postcard/src/lib.rs
+++ b/source/postcard/src/lib.rs
@@ -60,6 +60,9 @@ pub mod experimental {
         pub use crate::max_size::MaxSize;
         // NOTE: ...and this is the derive macro
         pub use postcard_derive::MaxSize;
+        // Private utility for generated code
+        #[doc(hidden)]
+        pub use crate::max_size::max_of_variants;
     }
 
     pub use crate::ser::serialized_size;

--- a/source/postcard/src/max_size.rs
+++ b/source/postcard/src/max_size.rs
@@ -347,6 +347,20 @@ const fn max(lhs: usize, rhs: usize) -> usize {
     }
 }
 
+/// Returns the max size in a slice of variant sizes, or zero if the slice is empty.
+#[doc(hidden)] // used only in macro codegen
+pub const fn max_of_variants(sizes: &[usize]) -> usize {
+    let (mut max, mut idx) = (0, 0);
+    while idx < sizes.len() {
+        let size = sizes[idx];
+        if size > max {
+            max = size;
+        }
+        idx += 1;
+    }
+    max
+}
+
 #[cfg(any(feature = "alloc", feature = "use-std"))]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Avoids generating nested expressions proportional to the number of variants, instead generating a slice of variant sizes and using a const function to determine the max size.

Also avoids generating unnecessary `0 + ` fragments.

Fixes #286

Before
```rust
impl ::postcard::experimental::max_size::MaxSize for Bar {
    const POSTCARD_MAX_SIZE: usize = 1usize
        + {
            let lhs = {
                let lhs = 0;
                let rhs = 0
                    + <u16 as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE;
                if lhs > rhs { lhs } else { rhs }
            };
            let rhs = 0
                + <u8 as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE;
            if lhs > rhs { lhs } else { rhs }
        };
}
```

After
```rust
impl ::postcard::experimental::max_size::MaxSize for Bar {
    const POSTCARD_MAX_SIZE: usize = 1usize
        + ::postcard::experimental::max_size::max_of_variants(
            &[
                <u16 as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE,
                <u8 as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE,
            ],
        );
}
```