### PR TITLE
Implement MaxSize and Schema for enum_map::EnumMap

### DIFF
--- a/source/postcard-schema-ng/Cargo.toml
+++ b/source/postcard-schema-ng/Cargo.toml
@@ -85,6 +85,12 @@ package = "serde-big-array"
 version = "0.5.1"
 optional = true
 
+[dependencies.enum-map_v3_0]
+package = "enum-map"
+version = "3.0.0"
+default-features = false
+optional = true
+
 [dev-dependencies.postcard]
 path = "../postcard"
 version = "1.0"
@@ -107,6 +113,7 @@ core-num-saturating = []
 
 chrono-v0_4 = ["chrono_v0_4"]
 defmt-v0_3 = ["defmt_v0_3"]
+enum-map-v3_0 = ["enum-map_v3_0"]
 fixed-v1_0 = ["fixed_v1_0"]
 heapless-v0_7 = ["heapless_v0_7"]
 heapless-v0_8 = ["heapless_v0_8"]

--- a/source/postcard-schema-ng/src/impls/enum_map_v3_0.rs
+++ b/source/postcard-schema-ng/src/impls/enum_map_v3_0.rs
@@ -1,0 +1,9 @@
+//! Implementations of the [`Schema`] trait for the `enum-map` crate v3
+
+use crate::{schema::DataModelType, Schema};
+
+#[cfg_attr(docsrs, doc(cfg(feature = "enum-map-v3_0")))]
+impl<K: enum_map_v3_0::Enum<Array<V>: Schema>, V: Schema> Schema for enum_map_v3_0::EnumMap<K, V> {
+    // K::Array is guaranteed to be [T; N]
+    const SCHEMA: &'static DataModelType = K::Array::SCHEMA;
+}

--- a/source/postcard-schema-ng/src/impls/mod.rs
+++ b/source/postcard-schema-ng/src/impls/mod.rs
@@ -18,6 +18,10 @@ pub mod builtins_std;
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono-v0_4")))]
 pub mod chrono_v0_4;
 
+#[cfg(feature = "enum-map-v3_0")]
+#[cfg_attr(docsrs, doc(cfg(feature = "enum-map-v3_0")))]
+pub mod enum_map_v3_0;
+
 #[cfg(feature = "fixed-v1_0")]
 #[cfg_attr(docsrs, doc(cfg(feature = "fixed-v1_0")))]
 pub mod fixed_v1_0;

--- a/source/postcard/Cargo.toml
+++ b/source/postcard/Cargo.toml
@@ -80,6 +80,12 @@ version = "0.33.0"
 optional = true
 default-features = false
 
+[dependencies.enum-map-v3_0]
+package = "enum-map"
+version = "3.0.0"
+default-features = false
+optional = true
+
 [dev-dependencies.serde]
 version = "1.0.100"
 default-features = false
@@ -126,3 +132,4 @@ heapless = ["dep:heapless"]
 postcard-derive = ["dep:postcard-derive"]
 heapless-v0_8 = ["dep:heapless-v0_8"]
 heapless-v0_9 = ["dep:heapless-v0_9"]
+enum-map-v3_0 = ["dep:enum-map-v3_0"]

--- a/source/postcard/src/max_size.rs
+++ b/source/postcard/src/max_size.rs
@@ -314,6 +314,13 @@ impl<T: MaxSize + nalgebra_v0_33::Scalar> MaxSize for nalgebra_v0_33::Quaternion
     const POSTCARD_MAX_SIZE: usize = nalgebra_v0_33::Vector4::<T>::POSTCARD_MAX_SIZE;
 }
 
+#[cfg(all(feature = "enum-map-v3_0", feature = "experimental-derive"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "enum-map-v3_0")))]
+impl<K: enum_map_v3_0::Enum<Array<V>: MaxSize>, V> MaxSize for enum_map_v3_0::EnumMap<K, V> {
+    // K::Array is guaranteed to be [T; N]
+    const POSTCARD_MAX_SIZE: usize = K::Array::POSTCARD_MAX_SIZE;
+}
+
 #[cfg(any(
     feature = "heapless",
     feature = "heapless-v0_8",


### PR DESCRIPTION
This was requested in `enum_map`, with the pull request at https://codeberg.org/sugar700/enum-map/pulls/170, however I decided against that due to experimental status of `MaxSize` trait.

I also implemented `Schema`, mostly because I could do so.