### PR TITLE
chore(postcard-derive): allow `syn` v3

### DIFF
--- a/source/postcard-derive-ng/Cargo.toml
+++ b/source/postcard-derive-ng/Cargo.toml
@@ -28,6 +28,6 @@ proc-macro = true
 all-features = true
 
 [dependencies]
-syn = "2.0"
+syn = ">= 2.0, < 4"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/source/postcard-derive/Cargo.toml
+++ b/source/postcard-derive/Cargo.toml
@@ -28,6 +28,6 @@ proc-macro = true
 all-features = true
 
 [dependencies]
-syn = "2.0"
+syn = ">= 2.0, < 4"
 quote = "1.0"
 proc-macro2 = "1.0"


### PR DESCRIPTION
Following the [recent release of `syn` v3](https://github.com/dtolnay/syn/releases/tag/3.0.0), this allows using the new version as a dependency of `postcard-derive` and `postcard-derive-ng`, with the aim of reducing dependency duplication in dependents.

[`syn` v3 advertises an MSRV of 1.71](https://crates.io/crates/syn/3.0.0/code/Cargo.toml#L14) and it's unclear to me what `postcard`'s MSRV is intended to be, but because this allows both `syn` v2 and v3, this shouldn't affect the MSRV (as a compatible version of `syn` v2 could still be selected by dependents if needed).

`syn` v3 of course contains breaking changes: I've been through the changelog but didn't find anything relevant (but there are quite a few of them so I could have missed some). I've run `cargo test` but didn't do any other kind of testing.